### PR TITLE
Refine builder prompts with track-specific workflows

### DIFF
--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/PHASE-3_INTEGRATION_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/PHASE-3_INTEGRATION_v0.0.1.md
@@ -1,0 +1,90 @@
+**Subject: Phase 3: Cross-Component Integration, End-to-End Assembly, and Shared Infrastructure Enablement for [Project Name]**
+
+**Date:** [Customizer: Enter Current Date]
+**Time:** [Customizer: Enter Current Time with UTC Offset]
+
+**1. Overall Purpose**
+This prompt initiates **Phase 3: System Integration & Assembly** for the **[Project Name]** initiative. The autonomous agent executing this prompt must:
+    a. Consolidate outputs from previously completed component builds (Phase 2 iterations) and confirm readiness for integration.
+    b. Design and implement the cross-component wiring, shared infrastructure services, and interface contracts exactly as specified in the Phase 1 Architectural Blueprint and updated Phase 2 deliverables.
+    c. Execute comprehensive integration validation (functional, data, workflow) ensuring components operate cohesively within the target environment.
+    d. Update shared documentation, diagrams, and configuration artifacts to reflect the assembled system state.
+
+**2. Core Execution Principles & Global Rules (MANDATORY - REITERATE WITH INTEGRATION FOCUS)**
+*(Customizer Note: Maintain verbatim structure; adjust bracketed content only.)*
+
+* **Apex Standards Adherence:** Continuous compliance with the **Apex Software Compliance Standards Guide** (located at `[User Input: Path to Standards Guide]`) is non-negotiable. Every integration artifact (code, scripts, infra definitions, tests, docs) must reference applicable `[(Rule #X: CODE)](...)` links.
+* **Strict Sequential Execution:** Follow the generated Phase 3 plan in strict `Phase -> Task -> Step` order (`- [ ]`). Do not advance until current items meet `Internal Success Criteria` validated through `Internal Verification Method`.
+* **Internal Verification & Standards Compliance:** Each integration task requires explicit verification against functional expectations and all linked standards.
+* **Recursive Error Handling / Retry Logic:** Halt on any integration defect, analyze the root cause, remediate, and re-run verifications until success.
+* **Autonomous Operation & Internal Logging:** Operate autonomously. Record integration outcomes and test metrics in the internal log as dictated by Section 5.
+
+**3. Mandatory Quality & Finalization Rules (Integration Emphasis)**
+*(Customizer Note: Keep structure; inject additional rules if Phase 1 blueprint mandates them.)*
+
+Enforce all relevant rules from the **Apex Software Compliance Standards Guide** (`[User Input: Path to Standards Guide]`) with heightened attention to:
+* Code Quality & Structure (Section 8: `QUAL-*`, including `QUAL-SIZE` for shared modules)
+* Configuration Management (Section 12: `CONF-*`)
+* Security & Access Controls across components (Section 13: `SEC-*`)
+* Data Integrity & Migration (Reference applicable `DATA-*` rules if defined)
+* Testing & Verification (Section 14: `TEST-*`, focus on integration and regression coverage)
+* Deployment & Infrastructure (Section 17: `DEP-*` if applicable)
+* Documentation & Knowledge Transfer (Section 18: `DOC-*`)
+* Final Validation (Section 21: `FINAL-*`)
+
+**4. Directive Section: Phase 3 - System Integration & Assembly**
+
+* **Context Provided by User (Customizer Checklist):**
+    * `[User Input: Project Name]`
+    * `[User Input: List of Components Completed in Phase 2]`
+    * `[User Input: Phase 1 Blueprint Path]`
+    * `[User Input: Phase 2 Deliverables Path(s)]`
+    * `[User Input: Path to Standards Guide]`
+    * `[User Input: Current Environment/Repository State Reference]`
+
+* **Instructions for Worker LLM:**
+
+    1.  **Confirm Integration Scope:**
+        * Identify all components slated for integration in this phase using `[List of Components Completed in Phase 2]` and cross-reference dependencies from the Phase 1 blueprint.
+        * Enumerate integration interfaces, shared contracts, data exchange formats, and infrastructure services required.
+        * Validate availability of prerequisite artifacts (code modules, schemas, configs) from prior phases.
+
+    2.  **Generate Detailed Integration Execution Plan:**
+        * Produce a `Phase -> Task -> Step` plan (`- [ ]`) covering:
+            * Environment preparation and dependency synchronization.
+            * Interface binding, adapter creation, or API gateway configuration.
+            * Data migration/synchronization scripts if needed.
+            * Integration test suite development & execution.
+            * Observability, logging correlation, and resilience hardening.
+            * Documentation updates (architecture diagrams, runbooks).
+        * Ensure each step includes precise `[(Rule #? : CODE)](...)` references.
+
+    3.  **Execute Integration Plan Sequentially:**
+        * Perform all plan items in order, modifying only files relevant to integration scope.
+        * Run all integration tests and regression checks defined.
+        * Capture logs/metrics per Section 5 and attach results to verification notes.
+        * Update shared docs/configs to reflect new system state.
+
+    4.  **Self-Verify & Summarize:**
+        * Confirm the integrated system meets functional & NFR expectations defined in the Phase 1 blueprint.
+        * Validate all success criteria & verification methods have been satisfied.
+        * Prepare a concise integration summary (components involved, interfaces activated, tests executed, outstanding risks).
+
+* **Internal Success Criteria (Worker LLM Self-Check):** All components listed for integration are wired together per blueprint, integration tests pass, shared configs/docs updated, and logs captured.
+* **Internal Verification Method:** Review execution trace, confirm test results, ensure documentation alignment, verify standards compliance for all touched items.
+
+**5. Test Reporting Protocol (Internal)**
+*(Customizer Note: Keep consistent across phases.)*
+* **Log File Location:** `docs/Test_Result_Analysis.md`
+* **Data Points per Entry:** Date/Time, Scope (Integration Phase), Components, Test Suites, Pass/Fail, Key Metrics (latency, throughput, error rates), Summary Findings.
+* **Update Frequency:** After each major integration test suite or milestone.
+
+**6. Final Instruction**
+Execute all directives in Section 4 sequentially. Upon completion:
+    * Report integration status for **[Project Name]**.
+    * Provide references to modified files/configs.
+    * Supply test evidence and highlight any residual issues.
+    * Deliver the finalized integration execution plan with all checkboxes marked `- [x]`.
+
+**7. Contextual Footer**
+*(Instructions generated: [Customizer: Timestamp]. Location context: [Customizer: Location])* 

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/PHASE-4_VALIDATION_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/PHASE-4_VALIDATION_v0.0.1.md
@@ -1,0 +1,90 @@
+**Subject: Phase 4: System-Level Validation, Performance Hardening, and Defect Eradication for [Project Name]**
+
+**Date:** [Customizer: Insert Current Date]
+**Time:** [Customizer: Insert Current Time with UTC Offset]
+
+**1. Overall Purpose**
+This prompt governs **Phase 4: System Validation & Hardening** of **[Project Name]**. The executing agent must:
+    a. Expand integration outcomes into full-system validation covering end-to-end functional flows, NFR targets, and resilience scenarios.
+    b. Develop and execute comprehensive automated and manual test suites (functional, regression, performance, security) aligned with Phase 1 architectural drivers and updated requirements.
+    c. Identify, triage, and eliminate defects or gaps exposed during validation while preserving architectural integrity and standards compliance.
+    d. Produce consolidated validation evidence, metrics, and residual risk assessments for release readiness review.
+
+**2. Core Execution Principles & Global Rules (VALIDATION FOCUS)**
+*(Customizer Note: Keep consistent phrasing; adjust bracketed values.)*
+
+* **Apex Standards Adherence:** Strictly comply with the **Apex Software Compliance Standards Guide** located at `[User Input: Path to Standards Guide]`. Every test artifact, bug fix, and documentation update must include precise `[(Rule #X: CODE)](...)` references.
+* **Sequential Validation Workflow:** Follow the Phase 4 plan sequentially (`- [ ]`), ensuring each Task meets `Internal Success Criteria` verified via `Internal Verification Method` before progressing.
+* **Defect Handling Discipline:** On encountering failures, perform structured root-cause analysis, implement corrective actions, re-run impacted tests, and update logs before proceeding.
+* **Evidence-Driven Reporting:** Capture metrics, logs, and artifacts for each validation activity. Maintain traceability between tests and requirements/NFRs.
+* **Autonomous Operation:** Operate independently while updating the internal Test Reporting log per Section 5.
+
+**3. Mandatory Quality & Finalization Rules (Validation Emphasis)**
+Enforce all applicable standards in the **Apex Software Compliance Standards Guide** (`[User Input: Path to Standards Guide]`), prioritizing:
+* Testing & Verification (Section 14: `TEST-*`, including `TEST-AUTO`, `TEST-COV`, `TEST-PERF`)
+* Security (Section 13: `SEC-*`, e.g., `SEC-AUTH`, `SEC-INPUT`)
+* Reliability & Resilience (Reference `QUAL-REL` or equivalent rules if defined)
+* Implementation Correctness (Section 19: `IMPL-*`)
+* Documentation (Section 18: `DOC-*`, ensure test evidence & runbooks)
+* Configuration Management (Section 12: `CONF-*` for test environments)
+* Final Validation Protocols (Section 21: `FINAL-*`)
+
+**4. Directive Section: Phase 4 - Validation & Hardening**
+
+* **Context Provided by User (Customizer Inputs):**
+    * `[User Input: Project Name]`
+    * `[User Input: Phase 1 Architectural Drivers & NFR Targets Path]`
+    * `[User Input: Phase 2 & 3 Deliverables Paths]`
+    * `[User Input: Path to Standards Guide]`
+    * `[User Input: Current Codebase/Test Harness Location]`
+
+* **Instructions for Worker LLM:**
+
+    1.  **Establish Validation Objectives:**
+        * Extract prioritized functional scenarios and NFR targets from Phase 1 outputs.
+        * Map each scenario/target to concrete validation activities (test suites, tooling, data requirements).
+        * Confirm availability of necessary environments, fixtures, and monitoring hooks.
+
+    2.  **Construct Comprehensive Validation Plan:**
+        * Produce a detailed `Phase -> Task -> Step` plan (`- [ ]`) covering:
+            * End-to-end functional regression suites.
+            * Data integrity verification.
+            * Performance, load, and stress testing.
+            * Security and privacy assessments (static, dynamic as applicable).
+            * Resilience/chaos scenarios if specified.
+            * Bug triage and remediation workflow.
+            * Evidence aggregation & reporting tasks.
+        * Reference appropriate standards in each step.
+
+    3.  **Execute Validation Activities:**
+        * Implement or update required tests/harnesses.
+        * Run all planned test suites, capturing metrics & logs.
+        * Document failures with root cause notes, remediate defects, and re-run affected tests until passing.
+
+    4.  **Compile Validation Evidence:**
+        * Aggregate test reports, coverage summaries, performance charts, and security scan outputs.
+        * Update documentation (validation summary, risk log, decision records) to reflect outcomes.
+        * Ensure traceability from requirements/NFRs to test results.
+
+    5.  **Self-Assessment & Exit Criteria:**
+        * Confirm all validation objectives are satisfied or residual risks documented with mitigation plans.
+        * Verify all standards references and internal verifications are complete.
+        * Prepare readiness recommendation for Phase 5 (Release & Transition).
+
+* **Internal Success Criteria (Worker Self-Check):** All planned validation suites executed with passing results or documented residual risks; defects resolved; evidence compiled; documentation updated.
+* **Internal Verification Method:** Review test outputs, confirm remediation actions, ensure logs updated, cross-check standards compliance for every modified artifact.
+
+**5. Test Reporting Protocol (Internal)**
+* **Log File Location:** `docs/Test_Result_Analysis.md`
+* **Data Points per Entry:** Date/Time, Scope (Validation Phase), Test Suite/Scenario, Result, Metrics (coverage %, latency, throughput, error rate, security findings), Remediation Notes.
+* **Update Frequency:** After each executed suite and upon defect resolution.
+
+**6. Final Instruction**
+Execute the validation directives sequentially. Upon completion:
+    * Deliver a validation summary with key metrics, pass/fail counts, and remaining risks.
+    * Provide locations of generated reports/artifacts.
+    * Supply the executed validation plan with all tasks marked `- [x]`.
+    * State readiness recommendation for progression to Phase 5.
+
+**7. Contextual Footer**
+*(Instructions generated: [Customizer Timestamp]. Location context: [Customizer Location])* 

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/PHASE-5_RELEASE_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/PHASE-5_RELEASE_v0.0.1.md
@@ -1,0 +1,89 @@
+**Subject: Phase 5: Release Readiness, Documentation Finalization, and Transition Planning for [Project Name]**
+
+**Date:** [Customizer: Provide Current Date]
+**Time:** [Customizer: Provide Current Time with UTC Offset]
+
+**1. Overall Purpose**
+This prompt orchestrates **Phase 5: Release & Transition** for **[Project Name]**. The executing agent must:
+    a. Consolidate validated outputs into production-ready deliverables (code, infrastructure definitions, data artifacts).
+    b. Finalize all documentation (architecture, operations, user-facing materials) ensuring alignment with the standards and preceding phases.
+    c. Prepare deployment packages, release notes, and transition plans for operations/support teams.
+    d. Conduct final compliance checks, sign-offs, and knowledge transfer steps to conclude the build initiative.
+
+**2. Core Execution Principles & Global Rules (RELEASE FOCUS)**
+*(Customizer Note: Retain structure; substitute bracketed inputs.)*
+
+* **Apex Standards Adherence:** Rigorously enforce all applicable rules from the **Apex Software Compliance Standards Guide** at `[User Input: Path to Standards Guide]`. Every release artifact must include correct `[(Rule #X: CODE)](...)` references.
+* **Sequential Closure:** Execute the Phase 5 plan strictly in order, marking `- [x]` only after satisfying `Internal Success Criteria` verified via `Internal Verification Method`.
+* **Immutable Evidence:** Preserve immutable evidence of release readiness (reports, approvals, sign-offs) in version-controlled locations.
+* **Transition Accountability:** Ensure all operational handoffs include explicit ownership, runbooks, and escalation paths.
+* **Autonomous but Auditable:** Operate autonomously while maintaining detailed entries in the internal log per Section 5.
+
+**3. Mandatory Quality & Finalization Rules (Release Emphasis)**
+Enforce the **Apex Software Compliance Standards Guide** (`[User Input: Path to Standards Guide]`) with focus on:
+* Final Validation & Sign-Off (Section 21: `FINAL-*`, especially `FINAL-SWEEP`, `FINAL-REL`)
+* Documentation & Knowledge Transfer (Section 18: `DOC-*`)
+* Deployment & Release Management (Section 17: `DEP-*`, `REL-*` if defined)
+* Configuration & Secrets Management (Section 12: `CONF-*`, `SEC-SECRET`)
+* Security & Compliance (Section 13: `SEC-*`)
+* Implementation Correctness & Traceability (Section 19: `IMPL-*`)
+* Testing Evidence Preservation (Section 14: `TEST-*`)
+
+**4. Directive Section: Phase 5 - Release & Transition**
+
+* **Context Provided by User (Customizer Inputs):**
+    * `[User Input: Project Name]`
+    * `[User Input: Phase 4 Validation Summary Path]`
+    * `[User Input: Deployment Environment(s) & Access Details]`
+    * `[User Input: Path to Standards Guide]`
+    * `[User Input: Stakeholder/Operations Contacts]`
+
+* **Instructions for Worker LLM:**
+
+    1.  **Establish Release Scope & Criteria:**
+        * Review Phase 4 validation outcomes to confirm readiness.
+        * Enumerate release deliverables (code repositories, infrastructure templates, data seeds, documentation).
+        * Confirm acceptance criteria, sign-off authorities, and regulatory/compliance obligations.
+
+    2.  **Assemble Release Package:**
+        * Produce or update deployment artifacts (manifests, scripts, pipelines) ensuring they match target environment specifications.
+        * Generate migration scripts or data snapshots as required.
+        * Verify versioning, tagging, and changelog accuracy.
+
+    3.  **Finalize Documentation & Knowledge Transfer:**
+        * Update architectural documentation, API references, operations runbooks, support playbooks, and user guides.
+        * Document known limitations, feature toggles, and rollback strategies.
+        * Prepare training materials or briefing notes for stakeholders.
+
+    4.  **Conduct Release Readiness Review:**
+        * Facilitate internal checklist covering tests passed, approvals received, security reviews completed, and rollback validated.
+        * Capture sign-offs (digital approvals, recorded decisions) and store in repository.
+        * Ensure `docs/Test_Result_Analysis.md` reflects final test status.
+
+    5.  **Transition & Closure Activities:**
+        * Outline deployment schedule, responsible parties, communication plan, and escalation paths.
+        * Transfer monitoring dashboards, alerting configurations, and credentials per security policies.
+        * Archive final artifacts and update backlog with post-release follow-ups.
+
+    6.  **Self-Verification:**
+        * Confirm all release deliverables are complete, standards-compliant, version-controlled, and communicated.
+        * Validate documentation accuracy and accessibility.
+        * Summarize release readiness including outstanding risks or deferred items.
+
+* **Internal Success Criteria:** Release artifacts packaged, documentation finalized, approvals captured, transition plan published, and all standards references satisfied.
+* **Internal Verification Method:** Review package contents, verify documentation links, confirm approvals, ensure logs updated, double-check standards compliance for each deliverable.
+
+**5. Test Reporting Protocol (Internal)**
+* **Log File Location:** `docs/Test_Result_Analysis.md`
+* **Data Points per Entry:** Date/Time, Scope (Release Phase), Activity (e.g., Final Smoke Test, Deployment Dry Run), Result, Metrics/Notes, Approvals Recorded.
+* **Update Frequency:** After each release readiness activity, dry run, or sign-off.
+
+**6. Final Instruction**
+Execute the release and transition directives sequentially. Upon completion:
+    * Provide a comprehensive release package summary (artifacts, versions, locations).
+    * Deliver final documentation index and access instructions.
+    * Record approvals and transition plans.
+    * Present the completed Phase 5 execution plan with all checkboxes marked `- [x]` and declare project handoff readiness.
+
+**7. Contextual Footer**
+*(Instructions generated: [Customizer Timestamp]. Location context: [Customizer Location])* 

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/UX-UI_polish/PHASE-1_SETUP_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/UX-UI_polish/PHASE-1_SETUP_v0.0.1.md
@@ -1,0 +1,48 @@
+**Subject: Phase 1: UX/UI Polish Track — Experience Baseline & Design Alignment for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Phase 1 aligns the UX/UI polish track with architecture and product goals, establishing experience benchmarks and design deliverables that will guide later refinements. Scope is limited to UX/UI research and planning.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Reference architecture compendium, frontend plan, and cross-track briefs.
+* Apply standards `UX-STRAT`, `UI-GUIDE`, `ACC-STD`, `BRAND`, and `DOC-UX`.
+* Collaborate with product/marketing teams for brand alignment.
+
+**3. Mandatory Quality & Finalization Rules**
+Store artifacts in `UX-UI_polish/outputs/phase-1/`, including experience principles, style inventory, accessibility baseline, and roadmap.
+
+**4. Directive Section: UX/UI Polish Phase 1 Tasks**
+* **Input Context:**
+    * Architecture outputs, frontend blueprint, user research, brand guidelines.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 1.1: Experience Audit** *(Analysis)*
+        - [ ] Review requirements, personas, and user journeys; identify critical experience moments.
+        - [ ] Document heuristics and usability risks.
+    - [ ] **Task 1.2: Design System Alignment** *(Design)*
+        - [ ] Inventory existing design tokens/components; map gaps relative to frontend plan.
+        - [ ] Define typography, color, spacing, and motion guidelines referencing brand standards.
+    - [ ] **Task 1.3: Accessibility Baseline** *(Accessibility)*
+        - [ ] Establish accessibility goals (WCAG level, localization needs) and audit current assets.
+        - [ ] Provide remediation checklist for frontend implementation.
+    - [ ] **Task 1.4: Polish Roadmap** *(Planning)*
+        - [ ] Build Phase -> Task -> Step plan for UX/UI enhancements (micro-interactions, responsive behavior, visual polish).
+        - [ ] Identify dependencies on frontend/backend/security deliverables.
+    - [ ] **Task 1.5: Communication Pack** *(Enablement)*
+        - [ ] Create briefs for frontend/testing tracks outlining polish expectations and review cadence.
+        - [ ] Store quality checklist as `ux_ui_quality_checklist.md`.
+
+* **Internal Success Criteria:** Experience audit, design system alignment, accessibility baseline, roadmap, and briefs completed.
+* **Internal Verification Method:** Ensure outputs align with architecture, cite standards, and reside in correct directory.
+
+**5. Test Reporting Protocol (Internal)**
+Log planning readiness and dependencies in `docs/Test_Result_Analysis.md` tagged `UX-PH1`.
+
+**6. Final Instruction for this Phase**
+Share UX/UI plan with frontend and product leadership before commencing detailed polish work.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/UX-UI_polish/PHASE-2_BUILD_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/UX-UI_polish/PHASE-2_BUILD_v0.0.1.md
@@ -1,0 +1,48 @@
+**Subject: Phase 2: UX/UI Polish Track — Deliver Design Assets & Interaction Specifications for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Create high-fidelity design assets, interaction specs, and accessibility guidance that frontend engineers will implement. Scope includes design deliverables and documentation; no frontend code changes.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Follow experience principles, design system alignment, and accessibility baseline from Phase 1.
+* Apply standards `UI-SPEC`, `UX-INTERACTION`, `ACC-GUIDE`, `DOC-UX`, and `BRAND`.
+* Ensure assets are versioned and annotated for developers.
+
+**3. Mandatory Quality & Finalization Rules**
+Store outputs in `UX-UI_polish/outputs/phase-2/`, including Figma (or equivalent) exports, interaction specs, motion prototypes, and accessibility annotations.
+
+**4. Directive Section: UX/UI Polish Phase 2 Tasks**
+* **Input Context:**
+    * Frontend build plan, architecture constraints, brand assets, user research insights.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 2.1: Component Library Updates** *(Design)*
+        - [ ] Design or refine UI components required for Phase 2 frontend implementation, including responsive states.
+        - [ ] Document usage guidelines and variations.
+    - [ ] **Task 2.2: Screen & Flow Design** *(Design)*
+        - [ ] Produce high-fidelity screens/wireflows for prioritized user journeys.
+        - [ ] Annotate layout, spacing, microcopy, and error states.
+    - [ ] **Task 2.3: Interaction & Motion Specs** *(Interaction Design)*
+        - [ ] Define motion parameters, transitions, and micro-interactions; provide prototypes or animation references.
+        - [ ] Include accessibility considerations for motion sensitivity.
+    - [ ] **Task 2.4: Accessibility Guidance** *(Accessibility)*
+        - [ ] Provide color contrast validations, semantic structure recommendations, and assistive tech notes.
+        - [ ] Update accessibility checklist for frontend testing.
+    - [ ] **Task 2.5: Developer Handoff Package** *(Documentation)*
+        - [ ] Compile `ux_ui_build_handoff.md` summarizing assets, acceptance criteria, and review cadence.
+        - [ ] Organize files with naming conventions and versioning.
+
+* **Internal Success Criteria:** All prioritized components/screens/specs delivered with annotations, accessibility guidance updated, handoff package ready.
+* **Internal Verification Method:** Confirm assets align with architecture constraints, meet brand standards, and are accessible by frontend team.
+
+**5. Test Reporting Protocol (Internal)**
+Log design delivery status in `docs/Test_Result_Analysis.md` tagged `UX-PH2`.
+
+**6. Final Instruction for this Phase**
+Walk through assets with frontend team to ensure understanding before integration work.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/UX-UI_polish/PHASE-3_INTEGRATION_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/UX-UI_polish/PHASE-3_INTEGRATION_v0.0.1.md
@@ -1,0 +1,47 @@
+**Subject: Phase 3: UX/UI Polish Track — Review Implemented UI & Provide Iteration Guidance for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Evaluate frontend implementation against design specifications, accessibility standards, and experience goals. Provide feedback, defect reports, and updated assets as needed while staying within UX/UI scope.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Reference frontend integration builds, testing reports, and accessibility audits.
+* Apply standards `UX-REVIEW`, `UI-QA`, `ACC-VERIFY`, and `DOC-UX`.
+* All adjustments communicated via design updates or documented defects; no code changes.
+
+**3. Mandatory Quality & Finalization Rules**
+Store review artifacts in `UX-UI_polish/outputs/phase-3/`, including annotated screenshots, feedback logs, and updated design files.
+
+**4. Directive Section: UX/UI Polish Phase 3 Tasks**
+* **Input Context:**
+    * Frontend integration environment, testing reports, analytics (if available).
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 3.1: Implementation Review** *(Evaluation)*
+        - [ ] Compare implemented UI against design specs for layout, typography, color, and motion.
+        - [ ] Capture discrepancies with annotated screenshots or videos.
+    - [ ] **Task 3.2: Accessibility Verification** *(Accessibility)*
+        - [ ] Conduct manual and automated accessibility checks, focusing on keyboard navigation, screen reader support, and contrast.
+        - [ ] Document issues with severity and remediation guidance.
+    - [ ] **Task 3.3: Experience QA Sessions** *(User Validation)*
+        - [ ] Run usability walkthroughs or heuristic evaluations, noting friction points.
+        - [ ] Recommend improvements to microcopy or interactions as needed.
+    - [ ] **Task 3.4: Feedback Consolidation** *(Communication)*
+        - [ ] Maintain `ux_ui_integration_feedback.md` summarizing findings, priorities, and owning teams.
+        - [ ] Provide updated design assets if changes required.
+    - [ ] **Task 3.5: Alignment Meeting** *(Coordination)*
+        - [ ] Review findings with frontend/testing teams, ensuring acceptance and timelines for fixes.
+
+* **Internal Success Criteria:** Review completed, issues prioritized, updated assets delivered, alignment achieved with frontend/testing.
+* **Internal Verification Method:** Verify feedback log covers all target screens, ensure assets updated and accessible, confirm no direct code modifications.
+
+**5. Test Reporting Protocol (Internal)**
+Log review outcomes in `docs/Test_Result_Analysis.md` tagged `UX-PH3`.
+
+**6. Final Instruction for this Phase**
+Monitor remediation progress and prepare for validation sign-off once fixes applied.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/UX-UI_polish/PHASE-4_VALIDATION_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/UX-UI_polish/PHASE-4_VALIDATION_v0.0.1.md
@@ -1,0 +1,47 @@
+**Subject: Phase 4: UX/UI Polish Track — Experience Validation & Sign-Off for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Confirm that the implemented UI meets experience, brand, and accessibility standards before release. Produce evidence supporting overall validation efforts.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Apply standards `UX-VAL`, `UI-BRAND`, `ACC-CERT`, and `DOC-UX`.
+* Use release-candidate builds and production-like data.
+* Any unresolved issues must include remediation plan or waiver approved by stakeholders.
+
+**3. Mandatory Quality & Finalization Rules**
+Store validation artifacts in `UX-UI_polish/outputs/phase-4/`, including usability test reports, accessibility confirmations, brand compliance checklists, and sign-off forms.
+
+**4. Directive Section: UX/UI Polish Phase 4 Tasks**
+* **Input Context:**
+    * Updated designs, frontend build, testing validation plan, product requirements.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 4.1: Usability Validation** *(Testing)*
+        - [ ] Conduct usability sessions or heuristic evaluations covering critical flows.
+        - [ ] Document findings, satisfaction scores, and required improvements.
+    - [ ] **Task 4.2: Accessibility Certification** *(Accessibility)*
+        - [ ] Run final accessibility audits (manual + automated) confirming compliance with target WCAG level.
+        - [ ] Capture evidence (screenshots, audit logs) for each criterion.
+    - [ ] **Task 4.3: Brand & Visual Consistency Check** *(Brand)*
+        - [ ] Verify typography, color, iconography, and motion align with brand standards.
+        - [ ] Update brand compliance checklist with pass/fail results.
+    - [ ] **Task 4.4: Evidence Compilation** *(Documentation)*
+        - [ ] Assemble `ux_ui_validation_report.md` summarizing validation activities, outcomes, and outstanding issues.
+        - [ ] Provide recommendations for final adjustments or post-release enhancements.
+    - [ ] **Task 4.5: Sign-Off Coordination** *(Governance)*
+        - [ ] Obtain approvals from product, design leadership, and accessibility stakeholders.
+
+* **Internal Success Criteria:** Validation activities completed, evidence documented, approvals obtained or waivers recorded.
+* **Internal Verification Method:** Ensure each validation activity has associated evidence and signatures stored in the directory.
+
+**5. Test Reporting Protocol (Internal)**
+Log validation outcomes in `docs/Test_Result_Analysis.md` tagged `UX-PH4`.
+
+**6. Final Instruction for this Phase**
+Submit validation report to testing and architecture teams as part of release gating.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/UX-UI_polish/PHASE-5_RELEASE_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/UX-UI_polish/PHASE-5_RELEASE_v0.0.1.md
@@ -1,0 +1,48 @@
+**Subject: Phase 5: UX/UI Polish Track — Launch Readiness & Experience Stewardship for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Prepare UX/UI deliverables for launch, ensuring marketing, support, and operations understand the experience expectations. Provide guidance for monitoring user feedback post-release.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Follow `UX-REL`, `BRAND`, `ACC-OPS`, and `DOC-UX` standards.
+* Utilize validation report findings and architecture governance playbook.
+* Deliverables must be accessible to stakeholders and version controlled.
+
+**3. Mandatory Quality & Finalization Rules**
+Store outputs in `UX-UI_polish/outputs/phase-5/`, including experience brief, style guide snapshot, support FAQs, and feedback monitoring plan.
+
+**4. Directive Section: UX/UI Polish Phase 5 Tasks**
+* **Input Context:**
+    * UX/UI validation report, release plan, marketing launch materials, support requirements.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 5.1: Launch Experience Brief** *(Communication)*
+        - [ ] Summarize key user journeys, visual themes, and accessibility commitments for launch teams.
+        - [ ] Provide messaging guidance for marketing/support.
+    - [ ] **Task 5.2: Design System Snapshot** *(Documentation)*
+        - [ ] Export stable design tokens/components for release reference, noting version numbers.
+        - [ ] Document change log since last release.
+    - [ ] **Task 5.3: Support Enablement** *(Enablement)*
+        - [ ] Create FAQ and troubleshooting guide covering UI behaviours, known issues, and workarounds.
+        - [ ] Provide screenshot library or quick-reference cards.
+    - [ ] **Task 5.4: Feedback Monitoring Plan** *(Operations)*
+        - [ ] Define channels for collecting user feedback (analytics, surveys, support tickets) and analysis cadence.
+        - [ ] Outline process for triaging UX feedback into product backlog.
+    - [ ] **Task 5.5: Post-Launch Review Preparation** *(Improvement)*
+        - [ ] Schedule UX/UI post-launch review meetings and specify metrics to evaluate.
+        - [ ] Capture hypotheses for future enhancements based on validation findings.
+
+* **Internal Success Criteria:** Experience brief, design snapshot, support materials, and monitoring plan delivered; stakeholders informed.
+* **Internal Verification Method:** Ensure deliverables stored, versioned, and acknowledged by marketing/support teams.
+
+**5. Test Reporting Protocol (Internal)**
+Log release readiness confirmation in `docs/Test_Result_Analysis.md` tagged `UX-PH5`.
+
+**6. Final Instruction for this Phase**
+Provide ongoing support during launch and monitor user feedback per plan, ready to advise on quick follow-up improvements.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/architecture-design/PHASE-1_SETUP_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/architecture-design/PHASE-1_SETUP_v0.0.1.md
@@ -1,0 +1,65 @@
+**Subject: Phase 1: Architecture Track — Establish System Blueprint & Cross-Discipline Briefing for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Phase 1 for the architecture track creates the canonical system vision that every other implementation lane (frontend, backend, networking, security, testing, UX/UI polish) must consume. The worker agent must:
+    a. Reconcile business goals, functional requirements, and non-functional drivers into explicit architectural objectives.
+    b. Select and justify structural patterns compatible with the Hybrid-Clean Architecture system card.
+    c. Produce a standards-linked blueprint plus hand-off packets that downstream tracks will reference verbatim.
+    d. Publish the authoritative dependency graph, interface contract catalog, and sequencing notes consumed by later phases.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+The worker must honour all corporate standards, with emphasis on:
+* **Architecture Rule of Precedence:** `[(Rule #01: ARCH-PRIME)](<path_to_standards>#arch-prime)` — architecture outputs drive the other tracks.
+* **Hybrid-Clean Architecture Compliance:** Preserve layer boundaries and dependency inversion in all diagrams and narratives.
+* **Traceability:** Every design decision must trace back to a requirement identifier.
+* **Sequenced Deliverables:** Downstream prompts rely on clearly enumerated artifacts. Missing artifacts block subsequent phases.
+* **Autonomous Validation:** Before finishing, re-read outputs to ensure completeness and alignment with the Apex Standards Guide at `[relative_path_to_standards]`.
+
+**3. Mandatory Quality & Finalization Rules**
+Enforce all quality gates defined in the standards guide, including `QUAL-*`, `ARCH-*`, `SEC-*`, `DATA-*`, `DOC-*`, and `PLAN-*`. If the system card introduces tighter constraints, explicitly cite them. No artifact can remain in draft state; each deliverable must carry version v0.0.1 and a change log stub.
+
+**4. Directive Section: Architecture Phase 1 Tasks**
+* **Input Context:**
+    * Project goal, requirements, constraints, and stakeholder roster supplied by the user.
+    * Standards location: `[relative_path_to_standards]`.
+    * Deliverable directory: `architecture-design/outputs/phase-1/`.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 1.1: Requirements Normalization** *(Setup/Meta)*
+        - [ ] Aggregate all functional & non-functional inputs into the `01_requirements_matrix.md` template.
+        - [ ] Flag ambiguities, conflicts, or missing data and request clarification channels.
+    - [ ] **Task 1.2: Architectural Driver Synthesis** *(Analysis)*
+        - [ ] Rank top architectural drivers (max 7) and justify each with requirement IDs and NFR metrics.
+        - [ ] Map each driver to the Hybrid-Clean layer(s) it influences.
+    - [ ] **Task 1.3: System Topology Definition** *(Design)*
+        - [ ] Evaluate at least two macro-architecture patterns (e.g., modular monolith vs. service-segmented monolith) against the drivers.
+        - [ ] Select the winning pattern, document rationale, and illustrate the layered topology using Mermaid.
+    - [ ] **Task 1.4: Component & Interface Ledger** *(Design)*
+        - [ ] Enumerate all core components per layer, specifying responsibilities, inbound/outbound ports, and owning teams.
+        - [ ] Produce the `interfaces_catalog.csv` capturing interface IDs, protocol, payload schema refs, and dependency direction.
+    - [ ] **Task 1.5: Cross-Track Enablement Packet** *(Enablement)*
+        - [ ] Draft targeted briefs for each track summarizing expectations, dependencies, and mandatory inputs they must read before Phase 1 in their lane. Store in `cross-track-briefs/`.
+        - [ ] Define configuration baseline, shared terminology, and artifact naming conventions.
+    - [ ] **Task 1.6: Build Sequencing & Milestones** *(Planning)*
+        - [ ] Create the architecture-first milestone plan identifying readiness gates for downstream tracks.
+        - [ ] Document gating criteria for hand-offs (e.g., frontend cannot start Phase 2 until UI contract doc `UX-FRONT-001` is signed-off).
+    - [ ] **Task 1.7: Consolidation & Verification** *(QA)*
+        - [ ] Compile the `phase-1_architecture_compendium.md` summarizing all outputs with hyperlinks.
+        - [ ] Run standards compliance checklist, confirm deliverables exist, and log verification in `docs/Test_Result_Analysis.md`.
+
+* **Internal Success Criteria:** All artifacts listed in Tasks 1.1–1.7 exist, are cross-referenced, and carry explicit standard citations.
+* **Internal Verification Method:** Perform a final walkthrough referencing the standards checklist, driver alignment table, and dependency graph. Any unresolved gap blocks completion.
+
+**5. Test Reporting Protocol (Internal)**
+* Log location: `docs/Test_Result_Analysis.md` (project root).
+* Entry format: Date/Time, Architecture Phase Step, Artifact Name, Compliance Result, Outstanding Risks.
+* Update cadence: After Task 1.7 completion.
+
+**6. Final Instruction for this Phase**
+Deliver the consolidated architecture package and notify downstream track leads that Phase 1 outputs are ready. Await acknowledgement before triggering other track prompts.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/architecture-design/PHASE-2_BUILD_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/architecture-design/PHASE-2_BUILD_v0.0.1.md
@@ -1,0 +1,53 @@
+**Subject: Phase 2: Architecture Track — Elaborate Layer Blueprints & Author Implementation Guardrails for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Architecture Phase 2 translates the Phase 1 blueprint into actionable guidance that each implementation lane will consume while starting their own Phase 1 setup. The worker agent must: (a) decompose each layer of the Hybrid-Clean stack into module-level specifications, (b) define interface contracts, quality bars, and acceptance gates, and (c) publish guardrail documents that keep downstream teams aligned with the architecture vision.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Use the canonical Phase 1 outputs as the only source of truth; do not revisit macro decisions unless blockers are discovered.
+* Every module spec must reference the requirements matrix IDs and cite relevant standards `[(Rule #X: CODE)](...)`.
+* Ensure portability: documentation must be technology-agnostic unless the stack decision is already locked.
+* Guardrail documents must be versioned, stored under `architecture-design/outputs/phase-2/`, and flagged as blocking dependencies in the milestone plan.
+
+**3. Mandatory Quality & Finalization Rules**
+Apply `ARCH-MOD`, `ARCH-INT`, `QUAL-DOC`, `SEC-PLAN`, and `TEST-ARCH` rules from the standards guide. Provide interface definitions in both prose and structured tables. Every artifact must include a "Downstream Consumers" section listing the tracks and phases that require it.
+
+**4. Directive Section: Architecture Phase 2 Tasks**
+* **Input Context:**
+    * Phase 1 compendium path: `architecture-design/outputs/phase-1/phase-1_architecture_compendium.md`.
+    * Requirements matrix and interface catalog from Phase 1.
+    * Standards guide path `[relative_path_to_standards]`.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 2.1: Layer Module Breakdown** *(Design Detailing)*
+        - [ ] For each clean architecture layer, enumerate modules/components and capture responsibilities in `layer_specs/<layer>.md`.
+        - [ ] Define data ownership and collaboration boundaries per module.
+    - [ ] **Task 2.2: Interface & Contract Authoring** *(Specification)*
+        - [ ] Produce protocol-neutral interface definitions, including request/response schemas, error models, and latency expectations.
+        - [ ] Link interfaces to the repository/port abstractions expected by backend and frontend tracks.
+    - [ ] **Task 2.3: Cross-Layer Guardrails** *(Governance)*
+        - [ ] Document anti-patterns to avoid (e.g., direct infrastructure calls from presentation) and enforcement strategy.
+        - [ ] Issue dependency inversion guidance summarizing approved interaction pathways.
+    - [ ] **Task 2.4: Acceptance Gates** *(Quality Control)*
+        - [ ] Define Definition of Ready/Definition of Done checklists tailored to each track.
+        - [ ] Establish verification hooks (e.g., architecture review checklists, ADR templates) and link them to tests or documentation deliverables.
+    - [ ] **Task 2.5: Risk Register Update** *(Risk Management)*
+        - [ ] Capture architectural risks introduced during detailing, mitigation plans, and monitoring triggers.
+    - [ ] **Task 2.6: Consolidation & Broadcast** *(Communication)*
+        - [ ] Update milestone plan with guardrail publication dates.
+        - [ ] Publish summary broadcast in `cross-track-briefs/architecture_phase2_summary.md`.
+
+* **Internal Success Criteria:** All layer specs, interface definitions, guardrail documents, and acceptance gates are published and linked.
+* **Internal Verification Method:** Run through each downstream track’s checklist ensuring every dependency referenced in their upcoming Phase 1 prompt has a matching artifact.
+
+**5. Test Reporting Protocol (Internal)**
+Log coverage of modules and guardrail sign-offs into `docs/Test_Result_Analysis.md`, capturing tracked risks and mitigation status.
+
+**6. Final Instruction for this Phase**
+Announce completion to downstream leads, providing quick links to Phase 2 outputs and calling out any risks requiring their acknowledgement.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/architecture-design/PHASE-3_INTEGRATION_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/architecture-design/PHASE-3_INTEGRATION_v0.0.1.md
@@ -1,0 +1,52 @@
+**Subject: Phase 3: Architecture Track — Multi-Discipline Integration Oversight for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Architecture Phase 3 ensures every implementation track integrates according to the blueprint. The worker agent coordinates cross-track integration checkpoints, validates that in-flight deliverables adhere to architectural guardrails, and updates architectural assets when controlled changes are required.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Architecture remains the single source of truth. Any deviation must be recorded via Architecture Decision Records (ADRs).
+* Integration oversight focuses on contracts, data flow, and dependency order—not on authoring feature code.
+* Highlight blockers early; downstream tracks must not proceed if architectural prerequisites fail verification.
+* Align all actions with `ARCH-INT`, `ARCH-CHANGE`, `QUAL-REV`, and `TEST-SYS` standards.
+
+**3. Mandatory Quality & Finalization Rules**
+Maintain the change log for every architectural asset touched. Ensure integration checkpoints include traceability to requirements and risk register updates. Provide red/amber/green status for each track in the integration dashboard.
+
+**4. Directive Section: Architecture Phase 3 Tasks**
+* **Input Context:**
+    * Phase 1 & 2 outputs.
+    * Track-specific Phase 2 build plans (read-only) for frontend, backend, networking, security, testing, UX/UI polish.
+    * Standards guide `[relative_path_to_standards]`.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 3.1: Integration Control Board Kickoff** *(Coordination)*
+        - [ ] Schedule integration checkpoints aligned with milestone plan.
+        - [ ] Create `integration_dashboard.md` capturing track status, dependencies, and upcoming gates.
+    - [ ] **Task 3.2: Contract Verification** *(Compliance)*
+        - [ ] Review implementations against interface catalog, flagging mismatches in `integration_findings.md`.
+        - [ ] Ensure shared schemas and DTOs remain synchronized across repositories.
+    - [ ] **Task 3.3: Dependency Flow Audit** *(Analysis)*
+        - [ ] Validate build order adherence; document any out-of-order work and required remediations.
+    - [ ] **Task 3.4: Change Management** *(Governance)*
+        - [ ] For each requested architectural change, author an ADR with rationale, impact, and approvals.
+        - [ ] Update guardrail documents if changes are accepted.
+    - [ ] **Task 3.5: Risk & Issue Tracking** *(Risk Management)*
+        - [ ] Update risk register with integration-related items and mitigation dates.
+    - [ ] **Task 3.6: Broadcast & Alignment** *(Communication)*
+        - [ ] Share checkpoint outcomes, action items, and updated deadlines with track leads.
+        - [ ] Confirm receipt and agreement from each track lead.
+
+* **Internal Success Criteria:** Integration dashboard reflects real status; contracts verified; ADRs exist for any change; all tracks acknowledge action items.
+* **Internal Verification Method:** Conduct a retrospective checklist verifying each track’s compliance status, risk coverage, and acceptance of updates.
+
+**5. Test Reporting Protocol (Internal)**
+Record checkpoint results and contract verification findings in `docs/Test_Result_Analysis.md` with references to impacted artifacts.
+
+**6. Final Instruction for this Phase**
+Confirm that every track is aligned on integration outcomes and that architecture assets reflect the current state. If major blockers persist, escalate before Phase 4 validation begins.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/architecture-design/PHASE-4_VALIDATION_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/architecture-design/PHASE-4_VALIDATION_v0.0.1.md
@@ -1,0 +1,50 @@
+**Subject: Phase 4: Architecture Track — System Validation & Compliance Certification for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Phase 4 confirms that the implemented solution aligns with the sanctioned architecture. The worker agent executes architecture-focused validation, cross-checking implemented artifacts, test evidence, and documentation. The outcome is a certification package gating release readiness.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Validate against requirements, interface contracts, and guardrails established in Phases 1–3.
+* Utilize `ARCH-VAL`, `QUAL-AUD`, `TEST-SYS`, and `SEC-ARCH` standards for inspection depth.
+* Record objective evidence only; subjective assessments must be backed by traceable data (tests, metrics, screenshots).
+
+**3. Mandatory Quality & Finalization Rules**
+Maintain audit trails for every validation checklist. Any non-conformance must include remediation ownership and due dates. Certification cannot proceed until high-severity issues are resolved or formally waived by stakeholders.
+
+**4. Directive Section: Architecture Phase 4 Tasks**
+* **Input Context:**
+    * Implementation artifacts from all tracks.
+    * Integration dashboard and risk register from Phase 3.
+    * Standards guide `[relative_path_to_standards]` and guardrail documents.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 4.1: Validation Plan Setup** *(Planning)*
+        - [ ] Assemble validation scope matrix linking requirements to implemented components and test suites.
+        - [ ] Confirm availability of evidence repositories (CI logs, test reports, documentation).
+    - [ ] **Task 4.2: Architecture Conformance Audit** *(Inspection)*
+        - [ ] Review implementation snapshots, ensuring layering rules and dependency inversions remain intact.
+        - [ ] Document findings in `validation_reports/architecture_conformance.md` with pass/fail per component.
+    - [ ] **Task 4.3: Cross-Track Evidence Review** *(Verification)*
+        - [ ] Validate that each track provides evidence fulfilling Definition of Done/Ready criteria authored in Phase 2.
+        - [ ] Capture gaps, assign owners, and schedule remediation windows.
+    - [ ] **Task 4.4: Risk Closure & Waivers** *(Governance)*
+        - [ ] Reconcile risk register entries; mark mitigated, accepted, or residual.
+        - [ ] Draft waiver requests for unresolved risks requiring executive approval.
+    - [ ] **Task 4.5: Certification Packet Assembly** *(Output)*
+        - [ ] Compile the `architecture_validation_certificate_v0.0.1.md` summarizing compliance status, open issues, and waiver list.
+        - [ ] Obtain sign-off from architecture lead and key track owners.
+
+* **Internal Success Criteria:** Validation packet complete, all high severity issues resolved or waived, and certification signed.
+* **Internal Verification Method:** Run final audit checklist ensuring each requirement, interface, and guardrail has validation evidence.
+
+**5. Test Reporting Protocol (Internal)**
+Log validation outcomes and evidence references in `docs/Test_Result_Analysis.md`, tagging each entry with `ARCH-PH4`.
+
+**6. Final Instruction for this Phase**
+Publish the certification packet and distribute remediation assignments for remaining medium/low issues. Block release until sign-offs recorded.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/architecture-design/PHASE-5_RELEASE_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/architecture-design/PHASE-5_RELEASE_v0.0.1.md
@@ -1,0 +1,50 @@
+**Subject: Phase 5: Architecture Track — Release Governance & Operational Handoff for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Final phase ensures architecture deliverables are ready for production release and ongoing operations. The worker agent must formalize governance artifacts, support release planning, and hand off stewardship to operations and product leadership.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Leverage validated architecture artifacts only; do not introduce new structural changes unless critical defects arise.
+* Follow `ARCH-OPS`, `DOC-HANDOFF`, `SEC-OPS`, and `PLAN-RELEASE` standards.
+* All hand-off packages must be self-contained and accessible to operations teams.
+
+**3. Mandatory Quality & Finalization Rules**
+Archive finalized artifacts with immutable tags, ensure retention policies, and document operational contacts. Release governance requires sign-off from architecture, security, and operations leads.
+
+**4. Directive Section: Architecture Phase 5 Tasks**
+* **Input Context:**
+    * Certified validation packet from Phase 4.
+    * Release plan drafts from project management.
+    * Standards guide `[relative_path_to_standards]`.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 5.1: Governance Finalization** *(Governance)*
+        - [ ] Produce `architecture_governance_playbook.md` outlining change control, escalation paths, and KPIs.
+        - [ ] Define architectural health metrics for ongoing monitoring.
+    - [ ] **Task 5.2: Operational Readiness Support** *(Enablement)*
+        - [ ] Collaborate with operations to map architecture components to deployment topology and monitoring tooling.
+        - [ ] Provide runbooks or references ensuring architecture assumptions are upheld.
+    - [ ] **Task 5.3: Release Advisory** *(Planning)*
+        - [ ] Review release plan, confirm sequencing aligns with dependency graph, and note critical checkpoints.
+        - [ ] Document rollback triggers tied to architectural risk thresholds.
+    - [ ] **Task 5.4: Knowledge Transfer** *(Communication)*
+        - [ ] Conduct architecture hand-off session, capturing Q&A and decisions in `handoff_minutes.md`.
+        - [ ] Publish contact list and maintenance responsibilities.
+    - [ ] **Task 5.5: Archive & Closeout** *(Closeout)*
+        - [ ] Archive all architecture artifacts with version tags and checksum manifests.
+        - [ ] Update risk register to reflect post-release monitoring items.
+
+* **Internal Success Criteria:** Governance playbook completed, operational readiness confirmed, hand-off documented, archives sealed.
+* **Internal Verification Method:** Review with operations lead to confirm understanding and acceptance; verify archives and change control processes accessible.
+
+**5. Test Reporting Protocol (Internal)**
+Log release readiness approvals and outstanding watch items in `docs/Test_Result_Analysis.md` tagged `ARCH-PH5`.
+
+**6. Final Instruction for this Phase**
+Formally sign off on architecture track completion and transfer ongoing ownership to operations/governance teams.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/backend/PHASE-1_SETUP_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/backend/PHASE-1_SETUP_v0.0.1.md
@@ -1,0 +1,50 @@
+**Subject: Phase 1: Backend Track — Domain & Service Planning for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+This phase equips the backend track with the architecture context, domain understanding, and implementation roadmap required to build server-side capabilities. All activities stay within backend scope (business logic, domain, infrastructure abstractions) and exclude frontend or networking implementation.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Use architecture outputs: `architecture-design/outputs/phase-1/phase-1_architecture_compendium.md`, `layer_specs/business-logic.md`, and backend guardrail briefs.
+* Honour Hybrid-Clean Architecture: presentation layer never invoked directly; backend interacts via ports and adapters only.
+* Standards focus: `ARCH-BL`, `DOMAIN-MODEL`, `REPO-PATTERN`, `TEST-BACK`, `SEC-API`.
+* Document dependencies on database, security, and networking tracks.
+
+**3. Mandatory Quality & Finalization Rules**
+Store planning artifacts in `backend/outputs/phase-1/`. Include domain glossary, service catalog, and build plan referencing requirement IDs.
+
+**4. Directive Section: Backend Phase 1 Tasks**
+* **Input Context:**
+    * Architecture compendium, module specs, interface catalog.
+    * Business requirements and NFRs affecting backend (scalability, consistency, latency).
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 1.1: Domain Understanding** *(Analysis)*
+        - [ ] Create domain glossary and context map aligning bounded contexts with architecture layers.
+        - [ ] Identify aggregate roots, invariants, and transactional boundaries.
+    - [ ] **Task 1.2: Service & API Planning** *(Design)*
+        - [ ] Draft service catalog detailing responsibilities, exposed endpoints, and consumer tracks.
+        - [ ] Outline API style (REST/gRPC/etc.) referencing architecture directives.
+    - [ ] **Task 1.3: Data & Persistence Strategy** *(Design)*
+        - [ ] Map entities to data stores, define repository abstractions, and note consistency requirements.
+        - [ ] Capture data privacy/compliance constraints from security track.
+    - [ ] **Task 1.4: Technical Plan** *(Planning)*
+        - [ ] Produce Phase -> Task -> Step plan covering business logic, domain models, repository adapters, and test harnesses.
+        - [ ] Record required inputs from networking (service mesh, DNS) and security (auth providers).
+    - [ ] **Task 1.5: Quality Gates** *(Quality)*
+        - [ ] Establish coding standards, lint/test tooling, and observability requirements for backend modules.
+        - [ ] Store as `backend_quality_checklist.md`.
+
+* **Internal Success Criteria:** Domain map, service catalog, data strategy, and execution plan complete with dependencies noted.
+* **Internal Verification Method:** Ensure outputs align with architecture guardrails, cite standards, and remain backend-specific.
+
+**5. Test Reporting Protocol (Internal)**
+Record planning readiness and open dependencies in `docs/Test_Result_Analysis.md` tagged `BACK-PH1`.
+
+**6. Final Instruction for this Phase**
+Review plan with architecture and security leads, confirm readiness to commence backend implementation in Phase 2.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/backend/PHASE-2_BUILD_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/backend/PHASE-2_BUILD_v0.0.1.md
@@ -1,0 +1,55 @@
+**Subject: Phase 2: Backend Track — Implement Business Logic, Domain Models, and Adapters for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Implement the backend plan by delivering domain models, business services, and repository interfaces/adapters in accordance with Hybrid-Clean Architecture. Work must remain on backend components only.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Follow module specs in `architecture-design/outputs/phase-2/layer_specs/`.
+* Enforce dependency inversion: presentation code depends only on interfaces; infrastructure implements interfaces.
+* Apply standards `DOMAIN-PURE`, `APP-SERVICE`, `REPO-PATTERN`, `TEST-UNIT`, `TEST-INTEG`, `SEC-API`.
+* Each component must include tests, documentation, and observability hooks defined in Phase 1.
+
+**3. Mandatory Quality & Finalization Rules**
+* Organize code under `<src_root>/application`, `<src_root>/domain`, and `<src_root>/infrastructure` per architecture structure.
+* Maintain `backend/CHANGELOG.md` and update `backend_quality_checklist.md` as items complete.
+* Avoid touching frontend/networking/security directories except when defining contracts or stubs needed by backend.
+
+**4. Directive Section: Backend Phase 2 Tasks**
+* **Input Context:**
+    * Backend Phase 1 plan, architecture guardrails, interface catalog.
+    * Data schema definitions and infrastructure requirements.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 2.1: Project Scaffolding** *(Setup)*
+        - [ ] Set up folder structure, dependency injection container, and build tooling per standards.
+        - [ ] Create base interfaces for services and repositories.
+    - [ ] **Task 2.2: Domain Model Implementation** *(Domain)*
+        - [ ] Implement aggregates, value objects, and domain events with invariants enforced.
+        - [ ] Write unit tests validating domain behaviour without infrastructure dependencies.
+    - [ ] **Task 2.3: Application Service Layer** *(Business Logic)*
+        - [ ] Implement use-case services orchestrating domain operations via repositories and external service ports.
+        - [ ] Add application-level validation, error handling, and logging.
+    - [ ] **Task 2.4: Infrastructure Adapters** *(Adapters)*
+        - [ ] Implement repository adapters, external API clients, and messaging gateways respecting interface contracts.
+        - [ ] Configure transaction management and persistence mappings.
+    - [ ] **Task 2.5: Testing & Observability** *(Quality)*
+        - [ ] Create unit and integration tests hitting coverage targets; include contract tests for external interfaces.
+        - [ ] Instrument logging/metrics per observability requirements.
+    - [ ] **Task 2.6: Documentation & Readiness** *(Documentation)*
+        - [ ] Update developer documentation covering service endpoints, domain diagrams, and adapter configuration.
+        - [ ] Record outstanding issues or dependencies for integration phase.
+
+* **Internal Success Criteria:** All planned backend components implemented with tests and docs; quality checklist satisfied; no layer violations.
+* **Internal Verification Method:** Review dependency graph ensuring only allowed edges exist; confirm tests pass and documentation updated.
+
+**5. Test Reporting Protocol (Internal)**
+Log unit/integration test outcomes in `docs/Test_Result_Analysis.md` tagged `BACK-PH2`.
+
+**6. Final Instruction for this Phase**
+Package backend modules for integration testing and alert networking/security tracks of any required configuration.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/backend/PHASE-3_INTEGRATION_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/backend/PHASE-3_INTEGRATION_v0.0.1.md
@@ -1,0 +1,49 @@
+**Subject: Phase 3: Backend Track — Cross-Component Integration & Contract Verification for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Phase 3 integrates backend services with external systems (frontend, networking, security, data stores) and validates adherence to defined contracts. The worker agent ensures APIs, messaging, and persistence interactions behave as designed without implementing non-backend features.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Follow architecture integration dashboard scheduling and ADR decisions.
+* Use `TEST-CONTRACT`, `TEST-E2E-BACK`, `SEC-API`, and `DATA-CONSIST` standards.
+* Changes limited to backend modules; escalate issues owned by other tracks.
+
+**3. Mandatory Quality & Finalization Rules**
+Capture integration artifacts in `backend/outputs/phase-3/`, including test logs, schema validation results, and issue registers. Ensure data migration scripts are versioned and reversible.
+
+**4. Directive Section: Backend Phase 3 Tasks**
+* **Input Context:**
+    * Frontend contract tests, networking deployment topology, security auth flows.
+    * Integration dashboard and risk register.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 3.1: Environment Alignment** *(Setup)*
+        - [ ] Verify configuration for databases, message brokers, and external services matches architecture assumptions.
+        - [ ] Document environment variables/secrets required (without storing values) in `backend_env_requirements.md`.
+    - [ ] **Task 3.2: API Contract Verification** *(Testing)*
+        - [ ] Run automated contract tests against each endpoint, validating schemas, status codes, and error handling.
+        - [ ] Log discrepancies and collaborate with consuming tracks on remediation.
+    - [ ] **Task 3.3: Data Integration Testing** *(Data)*
+        - [ ] Execute integration tests covering persistence operations, migrations, and transactional integrity.
+        - [ ] Validate data seeding scripts and rollback procedures.
+    - [ ] **Task 3.4: Cross-Service Orchestration** *(Verification)*
+        - [ ] Test orchestrated workflows across backend modules (e.g., saga flows, event-driven pipelines).
+        - [ ] Monitor logs/metrics ensuring observability instrumentation meets expectations.
+    - [ ] **Task 3.5: Issue Tracking & Reporting** *(Communication)*
+        - [ ] Maintain `backend_integration_report.md` summarizing status, defects, and dependencies.
+        - [ ] Provide updates to architecture, networking, and security leads.
+
+* **Internal Success Criteria:** Integration tests passing, critical defects resolved or assigned, environment requirements documented.
+* **Internal Verification Method:** Review report, confirm evidence stored, ensure no scope creep beyond backend.
+
+**5. Test Reporting Protocol (Internal)**
+Update `docs/Test_Result_Analysis.md` with integration test results tagged `BACK-PH3`.
+
+**6. Final Instruction for this Phase**
+Signal readiness for validation testing and coordinate any outstanding cross-track fixes.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/backend/PHASE-4_VALIDATION_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/backend/PHASE-4_VALIDATION_v0.0.1.md
@@ -1,0 +1,51 @@
+**Subject: Phase 4: Backend Track — Service Validation & Reliability Assurance for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Validate backend services against functional, performance, reliability, and security requirements. The worker agent compiles objective evidence demonstrating that backend components comply with architecture standards and are ready for release.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Apply `TEST-SVC`, `PERF-API`, `RESILIENCE`, `SEC-API`, and `DOC-VAL` standards.
+* Use release-candidate builds and production-like data fixtures.
+* Do not modify frontend/security artifacts except to request fixes.
+
+**3. Mandatory Quality & Finalization Rules**
+Store results in `backend/outputs/phase-4/`. Include test reports, performance metrics, chaos/resilience findings, and compliance summaries.
+
+**4. Directive Section: Backend Phase 4 Tasks**
+* **Input Context:**
+    * Integration report, testing track validation plan, architecture certification checklist.
+    * Monitoring/observability requirements.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 4.1: Validation Plan Alignment** *(Planning)*
+        - [ ] Coordinate scope with testing track; define target environments and data sets.
+        - [ ] Document plan in `backend_validation_plan.md`.
+    - [ ] **Task 4.2: Functional & Regression Testing** *(Testing)*
+        - [ ] Execute automated regression suite covering service contracts and edge cases.
+        - [ ] Perform exploratory tests for complex workflows.
+    - [ ] **Task 4.3: Performance & Load Testing** *(Performance)*
+        - [ ] Run load/stress tests hitting defined throughput and latency goals.
+        - [ ] Capture resource utilization metrics and compare to budgets.
+    - [ ] **Task 4.4: Resilience & Chaos Exercises** *(Reliability)*
+        - [ ] Conduct failure injection scenarios (e.g., dependency outage, network latency) ensuring graceful degradation.
+        - [ ] Document recovery times and alerting behaviour.
+    - [ ] **Task 4.5: Security Verification** *(Security)*
+        - [ ] Validate authentication/authorization flows, input validation, and data protection requirements.
+        - [ ] Coordinate with security track on penetration test findings and remediations.
+    - [ ] **Task 4.6: Evidence Compilation** *(Documentation)*
+        - [ ] Assemble `backend_validation_report.md` summarizing results, open issues, and sign-off fields.
+
+* **Internal Success Criteria:** Validation plan executed, evidence recorded, no unresolved critical defects; sign-offs prepared.
+* **Internal Verification Method:** Ensure each requirement traced to validation evidence; confirm results stored and referenced.
+
+**5. Test Reporting Protocol (Internal)**
+Update `docs/Test_Result_Analysis.md` with validation outcomes tagged `BACK-PH4`.
+
+**6. Final Instruction for this Phase**
+Provide validation report to architecture and testing leads for certification approval.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/backend/PHASE-5_RELEASE_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/backend/PHASE-5_RELEASE_v0.0.1.md
@@ -1,0 +1,49 @@
+**Subject: Phase 5: Backend Track — Release Preparation & Operations Handoff for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Finalize backend artifacts for production release, ensuring deployment pipelines, runbooks, and support processes are ready. Work is confined to backend assets and collaboration with operations/security.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Follow `REL-BACKEND`, `DOC-RUNBOOK`, `OPS-API`, `SEC-OPS`, and `DATA-OPS` standards.
+* Use validation outputs and architecture governance playbook as guidance.
+* Produce reproducible deployment artifacts (containers, migrations, configuration).
+
+**3. Mandatory Quality & Finalization Rules**
+Store outputs in `backend/outputs/phase-5/`. Include release notes, rollback strategies, database migration plans, and on-call rotation details.
+
+**4. Directive Section: Backend Phase 5 Tasks**
+* **Input Context:**
+    * Backend validation report, architecture governance playbook, release plan.
+    * Operations requirements (monitoring, alerting, scaling policies).
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 5.1: Deployment Artifact Finalization** *(Build)*
+        - [ ] Package backend services (container images or binaries) with version tags and checksums.
+        - [ ] Bundle migrations and seed scripts with rollback steps documented.
+    - [ ] **Task 5.2: Pipeline & Configuration Review** *(Automation)*
+        - [ ] Validate CI/CD pipeline stages, ensuring tests and security scans enforced.
+        - [ ] Document environment-specific configuration requirements.
+    - [ ] **Task 5.3: Operational Runbooks** *(Enablement)*
+        - [ ] Produce runbooks covering startup, shutdown, scaling, and incident response.
+        - [ ] Define monitoring dashboards, alert thresholds, and log aggregation expectations.
+    - [ ] **Task 5.4: Handoff & Training** *(Communication)*
+        - [ ] Conduct knowledge transfer with operations/security, capturing minutes and action items.
+        - [ ] Share release notes summarizing backend changes, APIs, and known limitations.
+    - [ ] **Task 5.5: Final Approvals & Archiving** *(Governance)*
+        - [ ] Collect sign-offs from architecture, security, and operations leads.
+        - [ ] Archive deployment artifacts and documentation with version metadata.
+
+* **Internal Success Criteria:** Deployment artifacts verified, pipelines reviewed, runbooks delivered, approvals obtained.
+* **Internal Verification Method:** Cross-check release deliverables against governance checklist and confirm storage locations.
+
+**5. Test Reporting Protocol (Internal)**
+Log release readiness and smoke test confirmations in `docs/Test_Result_Analysis.md` tagged `BACK-PH5`.
+
+**6. Final Instruction for this Phase**
+Hand off backend release package to operations and support go/no-go decision making.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/frontend/PHASE-1_SETUP_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/frontend/PHASE-1_SETUP_v0.0.1.md
@@ -1,0 +1,51 @@
+**Subject: Phase 1: Frontend Track — Context Intake & UI Architecture Planning for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+This phase prepares the frontend track to begin implementation by internalizing the architecture outputs, defining UI scope, and producing the roadmap for presentation layer delivery. The worker agent must focus exclusively on frontend responsibilities and avoid backend, infrastructure, or security implementation.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Architecture-design outputs are authoritative; reference `architecture-design/outputs/phase-1/phase-1_architecture_compendium.md` and `cross-track-briefs/frontend.md`.
+* Align all plans with Hybrid-Clean Architecture by keeping frontend in the presentation layer and interacting only through approved ports.
+* Use standards `UI-QUAL`, `UX-GUIDE`, `ACC-STD`, `DOC-UI`, and `TEST-UI` in the Apex guide.
+* Scope guard: produce plans, design assets, and dependencies solely for the frontend.
+
+**3. Mandatory Quality & Finalization Rules**
+Create artifacts under `frontend/outputs/phase-1/`. Each must cite relevant standards, list dependencies on backend/security/networking deliverables, and include acceptance criteria.
+
+**4. Directive Section: Frontend Phase 1 Tasks**
+* **Input Context:**
+    * Architecture compendium and guardrails.
+    * UX research, brand guidelines, and accessibility mandates (if provided).
+    * Standards guide `[relative_path_to_standards]`.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 1.1: Context Assimilation** *(Setup)*
+        - [ ] Summarize user roles, UI flows, and interface contracts relevant to the frontend.
+        - [ ] Record dependencies on backend APIs and security requirements.
+    - [ ] **Task 1.2: Presentation Layer Blueprint** *(Design)*
+        - [ ] Define the frontend application structure (routing map, state management strategy, component hierarchy) within `frontend_architecture.md`.
+        - [ ] Confirm alignment with architecture guardrails (no direct infrastructure access).
+    - [ ] **Task 1.3: Experience Planning** *(UX Coordination)*
+        - [ ] Map prioritized user journeys into storyboard or wireframe references.
+        - [ ] Capture accessibility and localization requirements per journey.
+    - [ ] **Task 1.4: Delivery Plan & Dependencies** *(Planning)*
+        - [ ] Create a Phase -> Task -> Step execution plan enumerating UI modules, shared component libraries, and integration points.
+        - [ ] Note prerequisites from backend/networking/security that must exist before each UI module starts.
+    - [ ] **Task 1.5: Verification Checklist** *(Quality)*
+        - [ ] Build a checklist covering coding standards, linting, testing, accessibility, and performance budgets to be enforced during Phase 2.
+        - [ ] Store as `frontend_delivery_checklist.md`.
+
+* **Internal Success Criteria:** Frontend blueprint, execution plan, and quality checklist completed with dependencies identified.
+* **Internal Verification Method:** Review architecture alignment, ensure no backend tasks included, verify deliverables stored correctly.
+
+**5. Test Reporting Protocol (Internal)**
+Log Phase 1 readiness confirmation in `docs/Test_Result_Analysis.md` noting outstanding dependencies.
+
+**6. Final Instruction for this Phase**
+Present the frontend plan to architecture and UX leads for confirmation before commencing Phase 2 build work.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/frontend/PHASE-2_BUILD_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/frontend/PHASE-2_BUILD_v0.0.1.md
@@ -1,0 +1,56 @@
+**Subject: Phase 2: Frontend Track — Implement Presentation Layer Modules for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Execute the frontend build plan produced in Phase 1 by delivering UI components, routing, state management, and accessibility scaffolding. All work must stay within the presentation layer and respect backend interface boundaries defined by architecture.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Work only on frontend code within `<src_root>/presentation/...` as defined by the architecture documents.
+* Consume API contracts via typed clients or service interfaces generated per the backend guardrails; never invoke backend implementations directly.
+* Enforce `QUAL-FRONTEND`, `UI-STYLE`, `ACC-WCAG`, `TEST-UNIT`, and `TEST-VISUAL` rules.
+* Each module must include component documentation, storybook/demo entry (if applicable), and tests meeting coverage targets.
+
+**3. Mandatory Quality & Finalization Rules**
+* Place outputs under `frontend/src/` and `frontend/tests/` following architecture naming conventions.
+* Update `frontend_delivery_checklist.md` as tasks complete, keeping verification evidence.
+* Maintain changelog in `frontend/CHANGELOG.md` for each component release candidate.
+
+**4. Directive Section: Frontend Phase 2 Tasks**
+* **Input Context:**
+    * Phase 1 frontend plan and architecture guardrails.
+    * Mock API responses or schema definitions from backend track.
+    * Design assets or UX sign-offs.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 2.1: Environment Preparation** *(Setup)*
+        - [ ] Confirm tooling (package manager, bundler, linting, formatting) matches standards.
+        - [ ] Scaffold base app shell aligned with routing/state strategy.
+    - [ ] **Task 2.2: Component Implementation** *(Development)*
+        - [ ] Implement prioritized UI modules following the plan’s sequence, ensuring atomic commits per module.
+        - [ ] Include storybook stories or equivalent previews for each component group.
+    - [ ] **Task 2.3: API Integration Layer** *(Integration)*
+        - [ ] Generate API clients or hooks using backend interface definitions; include contract tests or mocks verifying schema compliance.
+        - [ ] Document fallback behaviour for API latency/failure states.
+    - [ ] **Task 2.4: Accessibility & Performance Hardening** *(Quality)*
+        - [ ] Run accessibility audits (automated + manual checklists) and record results.
+        - [ ] Establish performance budgets (bundle size, render timings) and validate against tooling.
+    - [ ] **Task 2.5: Testing & Verification** *(Testing)*
+        - [ ] Author unit/component tests hitting coverage thresholds.
+        - [ ] Configure visual regression or snapshot suite for critical screens.
+    - [ ] **Task 2.6: Documentation Update** *(Documentation)*
+        - [ ] Update developer guides for component usage, theming, and integration boundaries.
+        - [ ] Note outstanding dependencies or blockers for integration phase.
+
+* **Internal Success Criteria:** All planned modules implemented with tests, documentation updated, checklists satisfied, and no scope bleed beyond frontend.
+* **Internal Verification Method:** Review commits and artifacts ensuring only frontend directories touched; cross-check with quality checklist.
+
+**5. Test Reporting Protocol (Internal)**
+Capture unit, component, and accessibility test outcomes in `docs/Test_Result_Analysis.md` tagged `FRONT-PH2`.
+
+**6. Final Instruction for this Phase**
+Prepare the integration demo package (component library, app shell) and notify backend and UX leads that the frontend is ready for API integration tests.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/frontend/PHASE-3_INTEGRATION_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/frontend/PHASE-3_INTEGRATION_v0.0.1.md
@@ -1,0 +1,51 @@
+**Subject: Phase 3: Frontend Track — Cross-Track Integration & UX Verification for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Phase 3 integrates the frontend modules with backend APIs, security controls, and networking layers defined by other tracks. The worker agent verifies contract adherence, resolves UI-side integration defects, and collaborates on end-to-end flow validation while remaining within the frontend scope.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Respect architecture integration checkpoints documented in `integration_dashboard.md`.
+* Frontend adjustments must occur within presentation layer boundaries; backend fixes are escalated rather than implemented here.
+* Apply `TEST-E2E`, `ACC-UX`, `SEC-UI`, and `QUAL-INTEG` standards.
+* Maintain synchronized mocks and fixtures with backend definitions.
+
+**3. Mandatory Quality & Finalization Rules**
+All integration evidence lives in `frontend/outputs/phase-3/`. Capture test runs, screenshots, and issue logs. Any deviations require tickets referencing architecture ADRs.
+
+**4. Directive Section: Frontend Phase 3 Tasks**
+* **Input Context:**
+    * Backend API endpoints, security flows, networking configs.
+    * Architecture integration dashboard and ADRs.
+    * Test plans from testing track.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 3.1: Integration Environment Sync** *(Setup)*
+        - [ ] Confirm environment variables, API gateways, and auth providers match expected configuration.
+        - [ ] Update frontend `.env` templates documenting required secrets (without storing values).
+    - [ ] **Task 3.2: Contract Validation** *(Testing)*
+        - [ ] Run contract and schema validation suites ensuring frontend clients respect backend contracts.
+        - [ ] Record mismatches and collaborate with backend/security teams for fixes.
+    - [ ] **Task 3.3: End-to-End Flow Exercise** *(Verification)*
+        - [ ] Execute prioritized user journeys end-to-end, capturing screenshots/videos for UX confirmation.
+        - [ ] Document performance observations (initial load, navigation) and compare to budgets.
+    - [ ] **Task 3.4: Defect Management** *(Quality)*
+        - [ ] Log integration defects in shared tracker, categorize by severity, and track resolution.
+        - [ ] Retest resolved issues to confirm closure.
+    - [ ] **Task 3.5: Integration Readout** *(Communication)*
+        - [ ] Summarize integration status, outstanding issues, and dependency needs in `frontend_integration_report.md`.
+        - [ ] Share with architecture, backend, security, and UX leads.
+
+* **Internal Success Criteria:** All critical flows validated, no open blocking defects owned by frontend, documentation and environment instructions updated.
+* **Internal Verification Method:** Review integration report, ensure evidence exists, confirm only frontend-side changes performed.
+
+**5. Test Reporting Protocol (Internal)**
+Log integration test outcomes and defect stats in `docs/Test_Result_Analysis.md` tagged `FRONT-PH3`.
+
+**6. Final Instruction for this Phase**
+Notify stakeholders of integration readiness for formal validation testing. Provide guidance on any conditional workarounds required.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/frontend/PHASE-4_VALIDATION_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/frontend/PHASE-4_VALIDATION_v0.0.1.md
@@ -1,0 +1,51 @@
+**Subject: Phase 4: Frontend Track — User-Facing Validation & Accessibility Certification for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Phase 4 validates the frontend experience against UX, accessibility, performance, and security acceptance criteria. The worker agent performs comprehensive testing and assembles the evidence package required by the architecture and testing tracks.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Follow `UI-VAL`, `ACC-WCAG`, `PERF-UI`, `SEC-UI`, and `DOC-VAL` standards.
+* Validation must use release-candidate builds and production-like configuration.
+* Any defect outside frontend scope must be reported to the owning track instead of fixed here.
+
+**3. Mandatory Quality & Finalization Rules**
+Results stored in `frontend/outputs/phase-4/`. Evidence includes screenshots, performance reports, accessibility audits, and test logs. Annotate each with requirement IDs and standards references.
+
+**4. Directive Section: Frontend Phase 4 Tasks**
+* **Input Context:**
+    * Integration report, architecture certification checklist, UX acceptance criteria.
+    * Testing track validation plan.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 4.1: Validation Plan Finalization** *(Planning)*
+        - [ ] Align with testing track on scope, environments, and success thresholds.
+        - [ ] Document plan in `frontend_validation_plan.md`.
+    - [ ] **Task 4.2: Functional Acceptance Testing** *(Testing)*
+        - [ ] Execute scripted end-user scenarios covering all critical paths.
+        - [ ] Capture pass/fail status with evidence for each scenario.
+    - [ ] **Task 4.3: Accessibility Compliance** *(Accessibility)*
+        - [ ] Run WCAG AA audits (automated + manual assistive tech checks) and record compliance status.
+        - [ ] Document remediation or waivers for any outstanding issues.
+    - [ ] **Task 4.4: Performance & Resilience Testing** *(Performance)*
+        - [ ] Measure core web vitals, page weight, and responsiveness under load.
+        - [ ] Validate offline/poor network behaviour if applicable.
+    - [ ] **Task 4.5: Security & Privacy Checks** *(Security)*
+        - [ ] Verify frontend handles tokens/session data per security track rules.
+        - [ ] Confirm no sensitive data exposure in logs or browser storage.
+    - [ ] **Task 4.6: Evidence Pack Assembly** *(Documentation)*
+        - [ ] Compile all findings into `frontend_validation_report.md` with sign-off fields for UX, testing, and architecture leads.
+
+* **Internal Success Criteria:** Validation plan executed, evidence recorded, sign-off ready with no unresolved critical issues.
+* **Internal Verification Method:** Cross-check report against validation plan to ensure every item has evidence and responsible owner.
+
+**5. Test Reporting Protocol (Internal)**
+Update `docs/Test_Result_Analysis.md` with validation outcomes tagged `FRONT-PH4`.
+
+**6. Final Instruction for this Phase**
+Submit evidence to architecture and testing tracks for certification approval.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/frontend/PHASE-5_RELEASE_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/frontend/PHASE-5_RELEASE_v0.0.1.md
@@ -1,0 +1,49 @@
+**Subject: Phase 5: Frontend Track — Release Packaging & Experience Handoff for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Phase 5 finalizes the frontend deliverable for production release, ensuring deployment artifacts, documentation, and support materials are complete. The worker agent focuses on presentation layer readiness and does not modify backend infrastructure.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Follow `REL-UI`, `DOC-HANDOFF`, `OPS-UI`, and `SEC-OPS` standards.
+* Release artifacts must align with the architecture governance playbook and operational requirements.
+* Deliverables include build outputs, deployment configuration references, and knowledge transfer resources.
+
+**3. Mandatory Quality & Finalization Rules**
+Store outputs in `frontend/outputs/phase-5/`. Ensure reproducible builds, versioned artifacts, and documented release notes. Record support contacts and on-call expectations.
+
+**4. Directive Section: Frontend Phase 5 Tasks**
+* **Input Context:**
+    * Validation report, architecture governance playbook, release plan.
+    * Operations requirements for hosting, monitoring, and alerts.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 5.1: Release Build Preparation** *(Build)*
+        - [ ] Generate production build using approved configuration.
+        - [ ] Capture build metadata (commit hash, tool versions, bundle sizes).
+    - [ ] **Task 5.2: Deployment Package Assembly** *(Packaging)*
+        - [ ] Prepare deployable artifact (e.g., static assets archive, container image instructions) with checksum manifest.
+        - [ ] Document environment variables and CDN/cache settings required.
+    - [ ] **Task 5.3: Operational Readiness** *(Enablement)*
+        - [ ] Provide runbook entries covering smoke tests, rollback strategy, and monitoring dashboards relevant to the frontend.
+        - [ ] List SLOs/SLIs tracked for the presentation layer.
+    - [ ] **Task 5.4: Communication & Training** *(Handoff)*
+        - [ ] Conduct knowledge transfer with support teams, capturing questions/answers in `frontend_handoff_minutes.md`.
+        - [ ] Publish release notes focusing on user-facing changes, known issues, and mitigation steps.
+    - [ ] **Task 5.5: Final Sign-off** *(Governance)*
+        - [ ] Obtain approvals from architecture, UX, testing, and operations stakeholders.
+        - [ ] Archive artifacts and update `frontend/CHANGELOG.md` with release entry.
+
+* **Internal Success Criteria:** Production build reproducible, deployment instructions complete, support teams briefed, sign-offs recorded.
+* **Internal Verification Method:** Cross-check release package against governance checklist and ensure all deliverables stored.
+
+**5. Test Reporting Protocol (Internal)**
+Log release smoke test results and approvals in `docs/Test_Result_Analysis.md` tagged `FRONT-PH5`.
+
+**6. Final Instruction for this Phase**
+Deliver final release package to operations and confirm readiness for go-live window.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/networking/PHASE-1_SETUP_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/networking/PHASE-1_SETUP_v0.0.1.md
@@ -1,0 +1,49 @@
+**Subject: Phase 1: Networking Track — Topology Planning & Connectivity Strategy for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Networking Phase 1 interprets the architecture blueprint to design the connectivity, routing, and infrastructure services required. The worker agent focuses on network aspects only, enabling backend/frontend/security teams with clear expectations and constraints.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Use architecture compendium, guardrails, and dependency maps as authoritative context.
+* Align with standards `NET-TOPO`, `NET-SEC`, `NET-OBS`, `OPS-NET`, and `CLOUD-POLICY` from the Apex guide.
+* Document relationships with security controls (firewalls, IAM), deployment environments, and external integrations.
+
+**3. Mandatory Quality & Finalization Rules**
+Store artifacts in `networking/outputs/phase-1/`. Deliverables include topology diagrams, environment matrices, and provisioning plans with explicit standards citations.
+
+**4. Directive Section: Networking Phase 1 Tasks**
+* **Input Context:**
+    * Architecture compendium, component dependencies, deployment strategy outline.
+    * Compliance requirements (e.g., regional residency, encryption standards).
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 1.1: Requirement Consolidation** *(Analysis)*
+        - [ ] Summarize networking requirements (latency, throughput, isolation, redundancy) from architecture and NFRs.
+        - [ ] Identify external integrations and regulatory constraints.
+    - [ ] **Task 1.2: Logical Topology Design** *(Design)*
+        - [ ] Draft logical network topology (VPCs/VNETs, subnets, service tiers) in `network_topology.md` with diagrams.
+        - [ ] Define connectivity between layers, shared services, and third-party endpoints.
+    - [ ] **Task 1.3: Environment Mapping** *(Planning)*
+        - [ ] Map environments (dev/test/stage/prod) to network segments, noting isolation requirements.
+        - [ ] Capture IP/CIDR allocations and DNS naming strategy.
+    - [ ] **Task 1.4: Dependency Briefs** *(Enablement)*
+        - [ ] Produce briefs for backend, security, and testing tracks describing required networking prerequisites.
+        - [ ] Highlight sequencing constraints (e.g., firewall rules needed before backend integration testing).
+    - [ ] **Task 1.5: Verification Checklist** *(Quality)*
+        - [ ] Build checklist covering provisioning standards, monitoring hooks, and compliance checks to enforce in later phases.
+        - [ ] Store as `networking_quality_checklist.md`.
+
+* **Internal Success Criteria:** Topology, environment plan, and briefs completed with dependencies identified.
+* **Internal Verification Method:** Validate against architecture guardrails and ensure no non-network tasks included.
+
+**5. Test Reporting Protocol (Internal)**
+Log planning readiness and open dependencies in `docs/Test_Result_Analysis.md` tagged `NET-PH1`.
+
+**6. Final Instruction for this Phase**
+Share topology and dependency briefs with architecture, backend, and security leads before provisioning work begins.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/networking/PHASE-2_BUILD_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/networking/PHASE-2_BUILD_v0.0.1.md
@@ -1,0 +1,52 @@
+**Subject: Phase 2: Networking Track — Provision Connectivity & Core Infrastructure for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Provision network resources according to the approved topology, establishing secure connectivity for all tracks. Work must be limited to networking components (VPCs/VNETs, subnets, gateways, firewalls, load balancers, DNS, etc.).
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Follow topology design, environment map, and quality checklist from Phase 1.
+* Apply standards `NET-PROV`, `INFRA-AS-CODE`, `SEC-EDGE`, `OBS-NET`, and `DR-NET`.
+* All provisioning must be expressed as infrastructure-as-code (IaC) when possible.
+
+**3. Mandatory Quality & Finalization Rules**
+Store IaC templates, configuration files, and documentation in `networking/outputs/phase-2/`. Track changes via version control, include tagging strategy, and document rollback procedures.
+
+**4. Directive Section: Networking Phase 2 Tasks**
+* **Input Context:**
+    * Topology diagrams, environment mapping, dependency briefs.
+    * Cloud provider accounts or datacenter configuration guides.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 2.1: IaC Framework Setup** *(Setup)*
+        - [ ] Configure IaC tooling (Terraform/Pulumi/etc.) with remote state and policy enforcement.
+        - [ ] Establish module/library structure for reusable networking components.
+    - [ ] **Task 2.2: Core Network Provisioning** *(Implementation)*
+        - [ ] Create VPCs/VNETs, subnets, routing tables, and gateways per environment.
+        - [ ] Implement segmentation and isolation (public/private subnets, service tiers).
+    - [ ] **Task 2.3: Security Edge Configuration** *(Security)*
+        - [ ] Define firewall rules, security groups, and network ACLs meeting security track requirements.
+        - [ ] Integrate with identity-aware proxies or zero-trust solutions as specified.
+    - [ ] **Task 2.4: Traffic Management Setup** *(Operations)*
+        - [ ] Provision load balancers, API gateways, and DNS entries per component needs.
+        - [ ] Document routing policies, health checks, and failover behaviour.
+    - [ ] **Task 2.5: Observability Enablement** *(Quality)*
+        - [ ] Configure flow logs, metrics, and alerting for critical networking components.
+        - [ ] Ensure logging destinations align with operations tooling.
+    - [ ] **Task 2.6: Documentation & Validation** *(Documentation)*
+        - [ ] Update `networking_runbook.md` with provisioning steps, dependencies, and verification commands.
+        - [ ] Record outstanding tasks for integration phase.
+
+* **Internal Success Criteria:** Networking resources provisioned via IaC, security controls enforced, documentation updated.
+* **Internal Verification Method:** Run IaC plan/apply validations, review logs/metrics, confirm configuration matches topology.
+
+**5. Test Reporting Protocol (Internal)**
+Log provisioning validation results in `docs/Test_Result_Analysis.md` tagged `NET-PH2`.
+
+**6. Final Instruction for this Phase**
+Notify backend and security tracks that networking infrastructure is available for integration, providing access instructions.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/networking/PHASE-3_INTEGRATION_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/networking/PHASE-3_INTEGRATION_v0.0.1.md
@@ -1,0 +1,49 @@
+**Subject: Phase 3: Networking Track — Cross-System Connectivity Validation for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Phase 3 verifies that networking components interoperate correctly with backend services, security controls, and external integrations. The worker agent focuses on connectivity, routing, and resilience checks, leaving application fixes to other tracks.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Align with integration dashboard and architecture risk register.
+* Apply `NET-TEST`, `SEC-NET`, `DR-NET`, and `OBS-NET` standards.
+* Document any configuration changes as IaC updates.
+
+**3. Mandatory Quality & Finalization Rules**
+Store evidence in `networking/outputs/phase-3/`, including connectivity test logs, latency measurements, and failover drills. Update runbooks and quality checklist as items close.
+
+**4. Directive Section: Networking Phase 3 Tasks**
+* **Input Context:**
+    * Backend service endpoints, security policies, monitoring dashboards.
+    * Integration dashboard schedule and ADRs.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 3.1: Connectivity Verification** *(Testing)*
+        - [ ] Validate routing between tiers, ensuring firewall rules allow expected traffic only.
+        - [ ] Run automated ping/traceroute/API connectivity checks per environment.
+    - [ ] **Task 3.2: Performance & Latency Assessment** *(Performance)*
+        - [ ] Measure network latency and throughput versus NFR targets.
+        - [ ] Identify hotspots and propose optimizations without implementing backend changes.
+    - [ ] **Task 3.3: Resilience & Failover Tests** *(Reliability)*
+        - [ ] Simulate component failures (link loss, gateway outage) and confirm failover mechanisms operate as designed.
+        - [ ] Document recovery times and alerting events.
+    - [ ] **Task 3.4: Security Alignment** *(Security)*
+        - [ ] Review network security logs for anomalies, confirm segmentation policies enforced.
+        - [ ] Coordinate with security track on penetration test findings related to networking.
+    - [ ] **Task 3.5: Reporting & Coordination** *(Communication)*
+        - [ ] Update `networking_integration_report.md` summarizing status, issues, and dependencies.
+        - [ ] Communicate required changes to backend/security teams with ticket references.
+
+* **Internal Success Criteria:** Connectivity verified, performance meets targets, failover validated, no unresolved critical networking issues.
+* **Internal Verification Method:** Review reports, ensure evidence stored, confirm scope remains networking-specific.
+
+**5. Test Reporting Protocol (Internal)**
+Log integration test outcomes in `docs/Test_Result_Analysis.md` tagged `NET-PH3`.
+
+**6. Final Instruction for this Phase**
+Confirm networking readiness for validation/testing phases and escalate any unresolved blockers.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/networking/PHASE-4_VALIDATION_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/networking/PHASE-4_VALIDATION_v0.0.1.md
@@ -1,0 +1,48 @@
+**Subject: Phase 4: Networking Track — Network Validation & Compliance Certification for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Validate that the networking environment meets functional, security, compliance, and resilience requirements prior to release. The worker agent produces objective evidence for architecture and security review.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Apply standards `NET-VAL`, `SEC-AUDIT`, `DR-TEST`, `OPS-NET`, and `COMPLIANCE-NET`.
+* Utilize production-like environments and configuration states.
+* Any change requests must be tracked via IaC with peer review.
+
+**3. Mandatory Quality & Finalization Rules**
+Store validation outputs in `networking/outputs/phase-4/`, including audit results, penetration test evidence, failover metrics, and compliance certificates.
+
+**4. Directive Section: Networking Phase 4 Tasks**
+* **Input Context:**
+    * Integration reports, security testing results, compliance requirements.
+    * Monitoring dashboards and alerting configurations.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 4.1: Validation Plan Alignment** *(Planning)*
+        - [ ] Coordinate with security/testing teams on scope, tools, and success criteria.
+        - [ ] Document plan in `networking_validation_plan.md`.
+    - [ ] **Task 4.2: Functional & Performance Verification** *(Testing)*
+        - [ ] Execute network performance tests (latency, bandwidth, packet loss) against targets.
+        - [ ] Verify load balancer health checks and routing policies under load.
+    - [ ] **Task 4.3: Security & Compliance Audits** *(Security)*
+        - [ ] Perform firewall rule audits, port scans, and policy compliance checks.
+        - [ ] Capture evidence for encryption-in-transit and segmentation requirements.
+    - [ ] **Task 4.4: Resilience & Disaster Recovery Tests** *(Reliability)*
+        - [ ] Run failover drills, multi-region cutover tests, or backup link activation per DR strategy.
+        - [ ] Document RTO/RPO results.
+    - [ ] **Task 4.5: Evidence Compilation** *(Documentation)*
+        - [ ] Assemble `networking_validation_report.md` summarizing outcomes, issues, and sign-offs from security/operations.
+
+* **Internal Success Criteria:** Validation plan executed, evidence compiled, outstanding issues documented with owners.
+* **Internal Verification Method:** Ensure each requirement and standard cited has matching evidence; confirm artifacts stored correctly.
+
+**5. Test Reporting Protocol (Internal)**
+Log validation outcomes in `docs/Test_Result_Analysis.md` tagged `NET-PH4`.
+
+**6. Final Instruction for this Phase**
+Submit validation report to architecture and security for certification sign-off before release preparation.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/networking/PHASE-5_RELEASE_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/networking/PHASE-5_RELEASE_v0.0.1.md
@@ -1,0 +1,49 @@
+**Subject: Phase 5: Networking Track — Release Readiness & Operations Handoff for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Finalize networking deliverables for production launch, ensuring operations teams have runbooks, monitoring, and escalation paths. The worker agent confines work to networking assets.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Follow `REL-NET`, `OPS-NET`, `DOC-RUNBOOK`, `SEC-OPS`, and `DR-OPS` standards.
+* Leverage validation evidence and architecture governance playbook.
+* Maintain IaC as the source of truth; manual changes require documented justifications.
+
+**3. Mandatory Quality & Finalization Rules**
+Outputs stored in `networking/outputs/phase-5/`. Provide release notes, change windows, rollback plans, and contact matrix for network operations.
+
+**4. Directive Section: Networking Phase 5 Tasks**
+* **Input Context:**
+    * Networking validation report, architecture governance playbook, release schedule.
+    * Operations requirements for monitoring, alerting, and capacity planning.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 5.1: Deployment Package Finalization** *(Packaging)*
+        - [ ] Tag IaC modules for release and export change manifests.
+        - [ ] Provide configuration snapshots for audit and rollback.
+    - [ ] **Task 5.2: Runbook Completion** *(Enablement)*
+        - [ ] Update `networking_runbook.md` with deployment steps, incident response, and maintenance tasks.
+        - [ ] Include diagrams referencing failover paths and escalation procedures.
+    - [ ] **Task 5.3: Monitoring & Alerting Setup** *(Operations)*
+        - [ ] Verify monitoring dashboards, alerts, and log pipelines align with SLOs.
+        - [ ] Document alert routing and on-call expectations.
+    - [ ] **Task 5.4: Handoff & Training** *(Communication)*
+        - [ ] Conduct knowledge transfer session with operations/security teams; capture minutes and open actions.
+        - [ ] Distribute release notes detailing network changes and dependencies on other tracks.
+    - [ ] **Task 5.5: Final Approvals & Archiving** *(Governance)*
+        - [ ] Obtain sign-offs from architecture, security, and operations leads.
+        - [ ] Archive IaC state files, diagrams, and runbooks with version metadata.
+
+* **Internal Success Criteria:** IaC tagged, runbooks complete, monitoring verified, approvals recorded.
+* **Internal Verification Method:** Cross-check deliverables against governance checklist; ensure artifacts accessible to operations.
+
+**5. Test Reporting Protocol (Internal)**
+Log release readiness confirmation in `docs/Test_Result_Analysis.md` tagged `NET-PH5`.
+
+**6. Final Instruction for this Phase**
+Transfer ownership to network operations and support go-live decision making.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/security/PHASE-1_SETUP_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/security/PHASE-1_SETUP_v0.0.1.md
@@ -1,0 +1,49 @@
+**Subject: Phase 1: Security Track — Threat Modeling & Control Strategy for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Security Phase 1 establishes the threat model, security requirements, and control roadmap that guide all other tracks. Work focuses strictly on security governance and planning, not on building application features.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Reference architecture compendium, risk register, and guardrails from architecture track.
+* Apply standards `SEC-REQ`, `SEC-THREAT`, `SEC-CONTROL`, `PRIVACY`, and `COMPLIANCE`.
+* Ensure alignment with regulatory frameworks relevant to the project.
+
+**3. Mandatory Quality & Finalization Rules**
+Store outputs in `security/outputs/phase-1/`. Deliverables include threat model, control matrix, security requirements traceability, and cross-track briefs.
+
+**4. Directive Section: Security Phase 1 Tasks**
+* **Input Context:**
+    * Architecture outputs, NFRs, compliance mandates.
+    * Existing corporate security policies.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 1.1: Context Review** *(Analysis)*
+        - [ ] Summarize assets, data classifications, and trust boundaries from architecture documents.
+        - [ ] Identify stakeholders and escalation paths.
+    - [ ] **Task 1.2: Threat Modeling** *(Design)*
+        - [ ] Build STRIDE (or equivalent) threat model covering each component and interaction.
+        - [ ] Rate risks and map mitigations to standards.
+    - [ ] **Task 1.3: Security Requirement Definition** *(Planning)*
+        - [ ] Document security requirements per component, mapped to requirement IDs and controls.
+        - [ ] Specify authentication, authorization, encryption, auditing, and privacy needs.
+    - [ ] **Task 1.4: Control Strategy & Roadmap** *(Enablement)*
+        - [ ] Create control matrix linking threats to preventive/detective controls and owning tracks.
+        - [ ] Sequence security deliverables across phases and note dependencies on other tracks.
+    - [ ] **Task 1.5: Communication Package** *(Communication)*
+        - [ ] Produce briefs for frontend, backend, networking, testing, and UX tracks describing required security integrations.
+        - [ ] Establish verification checklists for later phases and store as `security_quality_checklist.md`.
+
+* **Internal Success Criteria:** Threat model, requirements, control matrix, and briefs completed with traceability to standards.
+* **Internal Verification Method:** Validate coverage across components, confirm deliverables stored, ensure no non-security tasks included.
+
+**5. Test Reporting Protocol (Internal)**
+Log planning readiness and key risks in `docs/Test_Result_Analysis.md` tagged `SEC-PH1`.
+
+**6. Final Instruction for this Phase**
+Share security strategy with architecture and implementation leads before proceeding to control implementation.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/security/PHASE-2_BUILD_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/security/PHASE-2_BUILD_v0.0.1.md
@@ -1,0 +1,52 @@
+**Subject: Phase 2: Security Track — Implement Preventive & Detective Controls for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Deploy security controls identified in Phase 1, ensuring application teams can integrate authentication, authorization, encryption, and monitoring capabilities. Work is confined to security tooling, policies, and shared libraries; no application features are implemented here.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Follow threat model, control matrix, and quality checklist.
+* Apply standards `SEC-AUTH`, `SEC-AUTHZ`, `SEC-CRYPTO`, `SEC-LOG`, `SEC-DEV`.
+* Coordinate with backend/frontend/networking to ensure interfaces align with architecture.
+
+**3. Mandatory Quality & Finalization Rules**
+Place deliverables in `security/outputs/phase-2/`, including configuration templates, infrastructure policies, shared libraries, and documentation. All changes must be testable and version-controlled.
+
+**4. Directive Section: Security Phase 2 Tasks**
+* **Input Context:**
+    * Control matrix, architecture guardrails, identity provider capabilities.
+    * Compliance requirements for logging/auditing.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 2.1: Identity & Access Foundations** *(Implementation)*
+        - [ ] Configure identity provider/SSO integration, client registrations, and token lifetimes per requirements.
+        - [ ] Publish configuration guides and secrets management expectations (no secrets in repo).
+    - [ ] **Task 2.2: Authorization Framework** *(Implementation)*
+        - [ ] Provide role/permission models, policy definitions, and middleware packages for backend/frontend consumption.
+        - [ ] Document enforcement points and integration steps.
+    - [ ] **Task 2.3: Data Protection Controls** *(Security)*
+        - [ ] Define encryption standards (in transit, at rest) and deliver key management configurations.
+        - [ ] Supply data classification handling guidelines for each component.
+    - [ ] **Task 2.4: Security Logging & Monitoring** *(Observability)*
+        - [ ] Implement centralized logging schemas, event taxonomy, and alerting rules for security events.
+        - [ ] Provide integration instructions for other tracks to emit security telemetry.
+    - [ ] **Task 2.5: Secure Development Tooling** *(Enablement)*
+        - [ ] Configure SAST/DAST tools, dependency scanning, and secret scanning pipelines.
+        - [ ] Document usage requirements and thresholds for build pipelines.
+    - [ ] **Task 2.6: Documentation & Support** *(Documentation)*
+        - [ ] Update `security_runbook.md` with setup steps, integration instructions, and support contacts.
+        - [ ] Record outstanding dependencies for integration phase.
+
+* **Internal Success Criteria:** Controls deployed/configured, documentation provided, integration points ready for other tracks.
+* **Internal Verification Method:** Validate each control against threat model; ensure deliverables stored and versioned.
+
+**5. Test Reporting Protocol (Internal)**
+Log control deployment validation in `docs/Test_Result_Analysis.md` tagged `SEC-PH2`.
+
+**6. Final Instruction for this Phase**
+Notify other tracks that security controls are ready for integration, providing necessary credentials or onboarding steps.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/security/PHASE-3_INTEGRATION_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/security/PHASE-3_INTEGRATION_v0.0.1.md
@@ -1,0 +1,49 @@
+**Subject: Phase 3: Security Track — Cross-Track Security Integration & Verification for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Ensure security controls integrate correctly across frontend, backend, networking, and testing activities. The worker agent validates enforcement points, telemetry, and incident response workflows while remaining within the security domain.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Follow integration dashboard, threat model updates, and risk register.
+* Apply standards `SEC-TEST`, `SEC-MON`, `SEC-OPS`, and `PRIVACY-VAL`.
+* Collaborate with other tracks but avoid implementing their features.
+
+**3. Mandatory Quality & Finalization Rules**
+Store evidence in `security/outputs/phase-3/` including integration test results, audit logs, and remediation plans. Update security checklist and risk register.
+
+**4. Directive Section: Security Phase 3 Tasks**
+* **Input Context:**
+    * Backend/frontend integration artifacts, networking policies, logging infrastructure.
+    * Security tooling dashboards and alerting systems.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 3.1: Access Control Verification** *(Testing)*
+        - [ ] Execute authentication and authorization test suites across user roles.
+        - [ ] Validate token issuance, revocation, and session management behaviours.
+    - [ ] **Task 3.2: Data Protection Checks** *(Security)*
+        - [ ] Confirm encryption-in-transit and at-rest configurations across environments.
+        - [ ] Inspect sensitive data handling in logs and storage systems.
+    - [ ] **Task 3.3: Telemetry & Alert Validation** *(Observability)*
+        - [ ] Ensure security events are emitted, aggregated, and alert thresholds trigger appropriately.
+        - [ ] Verify incident response workflows and escalation paths.
+    - [ ] **Task 3.4: Vulnerability Management** *(Risk Management)*
+        - [ ] Review SAST/DAST/dependency scanning results, track remediation with owning teams.
+        - [ ] Update risk register entries with mitigation status.
+    - [ ] **Task 3.5: Integration Reporting** *(Communication)*
+        - [ ] Produce `security_integration_report.md` summarizing findings, open issues, and required actions for other tracks.
+        - [ ] Communicate results to architecture and operations leads.
+
+* **Internal Success Criteria:** Security controls verified across components, critical findings assigned, telemetry functioning.
+* **Internal Verification Method:** Review evidence, ensure traceability to threats/controls, confirm no scope creep beyond security tasks.
+
+**5. Test Reporting Protocol (Internal)**
+Log integration results in `docs/Test_Result_Analysis.md` tagged `SEC-PH3`.
+
+**6. Final Instruction for this Phase**
+Coordinate remediation with owning teams and confirm readiness for validation audits.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/security/PHASE-4_VALIDATION_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/security/PHASE-4_VALIDATION_v0.0.1.md
@@ -1,0 +1,47 @@
+**Subject: Phase 4: Security Track — Security Validation & Compliance Assurance for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Conduct formal security validation to confirm requirements, controls, and remediation actions are satisfied. Produce evidence for architecture certification and regulatory audits.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Apply standards `SEC-VAL`, `PEN-TEST`, `PRIVACY-AUDIT`, `COMP-REPORT`, and `SEC-OPS`.
+* Use production-equivalent environments and finalized configurations.
+* Track findings with severity levels and remediation owners.
+
+**3. Mandatory Quality & Finalization Rules**
+Store validation artifacts in `security/outputs/phase-4/`, including penetration test reports, compliance checklists, privacy assessments, and residual risk statements.
+
+**4. Directive Section: Security Phase 4 Tasks**
+* **Input Context:**
+    * Threat model, integration findings, risk register, validation plans from testing/architecture.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 4.1: Validation Plan Confirmation** *(Planning)*
+        - [ ] Align on test scope, tools, and success criteria with stakeholders.
+        - [ ] Document plan in `security_validation_plan.md`.
+    - [ ] **Task 4.2: Penetration & Vulnerability Testing** *(Testing)*
+        - [ ] Execute penetration tests (internal/external) and advanced vulnerability scans.
+        - [ ] Document findings with reproduction steps and severity ratings.
+    - [ ] **Task 4.3: Compliance & Privacy Review** *(Compliance)*
+        - [ ] Verify adherence to regulatory standards (e.g., GDPR, HIPAA) and corporate policies.
+        - [ ] Confirm data retention, consent management, and audit logging meet requirements.
+    - [ ] **Task 4.4: Risk Closure** *(Risk Management)*
+        - [ ] Update risk register, mark mitigated/accepted items, and document residual risks.
+        - [ ] Prepare waiver requests for any deferred fixes.
+    - [ ] **Task 4.5: Evidence Package Assembly** *(Documentation)*
+        - [ ] Compile `security_validation_report.md` summarizing activities, findings, remediation status, and sign-offs.
+
+* **Internal Success Criteria:** Validation completed, evidence recorded, critical findings closed or waived with approvals.
+* **Internal Verification Method:** Ensure every requirement/control has validation evidence; confirm documentation stored correctly.
+
+**5. Test Reporting Protocol (Internal)**
+Update `docs/Test_Result_Analysis.md` with validation results tagged `SEC-PH4`.
+
+**6. Final Instruction for this Phase**
+Provide security validation report to architecture and compliance stakeholders for release certification.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/security/PHASE-5_RELEASE_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/security/PHASE-5_RELEASE_v0.0.1.md
@@ -1,0 +1,49 @@
+**Subject: Phase 5: Security Track — Release Authorization & Operational Handoff for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Provide final security approval for production release, ensuring operational teams can maintain controls post-launch. Activities include governance sign-off, monitoring readiness, and incident response preparation.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Follow `REL-SEC`, `SEC-OPS`, `DOC-HANDOFF`, and `INCIDENT-RESP` standards.
+* Reference security validation report and architecture governance playbook.
+* Document ongoing compliance requirements and audit schedules.
+
+**3. Mandatory Quality & Finalization Rules**
+Outputs stored in `security/outputs/phase-5/`. Deliverables include security release memo, runbooks, monitoring thresholds, and on-call rotation assignments.
+
+**4. Directive Section: Security Phase 5 Tasks**
+* **Input Context:**
+    * Security validation report, architecture governance playbook, release schedule.
+    * Operations contact list and tooling access requirements.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 5.1: Release Memo & Approvals** *(Governance)*
+        - [ ] Draft security release memo summarizing validation status, residual risks, and required compensating controls.
+        - [ ] Collect approvals from CISO/security leadership.
+    - [ ] **Task 5.2: Operational Runbooks** *(Enablement)*
+        - [ ] Update `security_runbook.md` with incident response steps, alert escalations, and compliance monitoring tasks.
+        - [ ] Include references to tooling dashboards and playbooks.
+    - [ ] **Task 5.3: Monitoring & Alert Configuration** *(Operations)*
+        - [ ] Ensure security alerts, SIEM dashboards, and ticketing integrations are active with appropriate thresholds.
+        - [ ] Document alert routing and on-call rotation.
+    - [ ] **Task 5.4: Training & Handoff** *(Communication)*
+        - [ ] Conduct knowledge transfer with operations/support teams; capture Q&A and follow-up actions.
+        - [ ] Provide guidance on periodic security assessments and compliance reporting cadence.
+    - [ ] **Task 5.5: Archive & Audit Prep** *(Compliance)*
+        - [ ] Archive security evidence, validation reports, and risk registers for audit readiness.
+        - [ ] Schedule post-release security review milestones.
+
+* **Internal Success Criteria:** Release memo approved, runbooks updated, monitoring verified, handoff completed.
+* **Internal Verification Method:** Confirm approvals stored, documentation accessible, and operations acknowledge handoff responsibilities.
+
+**5. Test Reporting Protocol (Internal)**
+Log release readiness confirmation in `docs/Test_Result_Analysis.md` tagged `SEC-PH5`.
+
+**6. Final Instruction for this Phase**
+Authorize security release and transition oversight to operations while monitoring initial go-live window.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/testing/PHASE-1_SETUP_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/testing/PHASE-1_SETUP_v0.0.1.md
@@ -1,0 +1,48 @@
+**Subject: Phase 1: Testing Track — Quality Strategy & Test Architecture Planning for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Testing Phase 1 defines the quality strategy, test architecture, and plans that will guide verification efforts across all tracks. Work is limited to testing governance and planning.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Consume architecture compendium, requirements matrix, and guardrails.
+* Apply standards `TEST-STRAT`, `TEST-AUTO`, `TEST-ENV`, `QUAL-METRICS`, and `DOC-TEST`.
+* Coordinate with frontend, backend, networking, security, and UX teams to capture dependencies.
+
+**3. Mandatory Quality & Finalization Rules**
+Store artifacts in `testing/outputs/phase-1/`, including test strategy document, environment plan, tooling selections, and traceability matrix.
+
+**4. Directive Section: Testing Phase 1 Tasks**
+* **Input Context:**
+    * Architecture outputs, risk register, NFRs, compliance requirements.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 1.1: Requirement & Risk Analysis** *(Analysis)*
+        - [ ] Map functional and non-functional requirements to test coverage needs.
+        - [ ] Prioritize risks influencing testing depth.
+    - [ ] **Task 1.2: Test Architecture Definition** *(Design)*
+        - [ ] Define test levels (unit, integration, system, performance, security, UX) and responsibilities per track.
+        - [ ] Specify tooling frameworks and automation standards.
+    - [ ] **Task 1.3: Environment & Data Strategy** *(Planning)*
+        - [ ] Plan test environments, data management approach, and refresh cycles.
+        - [ ] Document dependencies on networking and security configurations.
+    - [ ] **Task 1.4: Traceability & Metrics** *(Quality)*
+        - [ ] Build requirements-to-test traceability matrix and quality metric definitions.
+        - [ ] Establish thresholds for coverage, defect leakage, and performance.
+    - [ ] **Task 1.5: Communication Plan** *(Enablement)*
+        - [ ] Produce cross-track testing brief highlighting responsibilities, entry/exit criteria, and reporting cadence.
+        - [ ] Create `testing_quality_checklist.md` to enforce standards in future phases.
+
+* **Internal Success Criteria:** Strategy, architecture, environment plan, traceability matrix, and communication plan completed.
+* **Internal Verification Method:** Confirm alignment with architecture outputs and ensure artifacts stored correctly.
+
+**5. Test Reporting Protocol (Internal)**
+Log planning readiness in `docs/Test_Result_Analysis.md` tagged `TEST-PH1`.
+
+**6. Final Instruction for this Phase**
+Share strategy with all track leads, confirming readiness to begin building test assets in Phase 2.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/testing/PHASE-2_BUILD_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/testing/PHASE-2_BUILD_v0.0.1.md
@@ -1,0 +1,48 @@
+**Subject: Phase 2: Testing Track — Build Automated & Manual Test Assets for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Create test suites, frameworks, and supporting assets aligned with the Phase 1 strategy. Work focuses on testing deliverables only.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Adhere to test architecture, tooling selections, and quality checklist.
+* Apply standards `TEST-AUTO`, `TEST-MAN`, `TEST-DATA`, `DOC-TEST`, and `CI-CD-TEST`.
+* Collaborate with other tracks to integrate tests without modifying their feature code.
+
+**3. Mandatory Quality & Finalization Rules**
+Store assets under `testing/outputs/phase-2/` (framework code, scripts, data sets, documentation). Ensure maintainability, modularity, and traceability to requirements.
+
+**4. Directive Section: Testing Phase 2 Tasks**
+* **Input Context:**
+    * Test strategy, environment plan, architecture guardrails, component specifications.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 2.1: Framework Setup** *(Implementation)*
+        - [ ] Configure base automation framework(s) for unit/integration/system tests.
+        - [ ] Establish folder structure, coding standards, and reusable utilities.
+    - [ ] **Task 2.2: Test Case Development** *(Development)*
+        - [ ] Implement automated tests per priority features and NFRs.
+        - [ ] Document manual exploratory test charters for complex scenarios.
+    - [ ] **Task 2.3: Test Data Management** *(Data)*
+        - [ ] Create synthetic data sets, anonymization processes, and refresh scripts.
+        - [ ] Ensure data complies with privacy/security requirements.
+    - [ ] **Task 2.4: CI/CD Integration** *(Automation)*
+        - [ ] Integrate test suites into pipelines with pass/fail gating criteria.
+        - [ ] Configure reporting dashboards and coverage metrics.
+    - [ ] **Task 2.5: Documentation & Training** *(Documentation)*
+        - [ ] Update `testing_runbook.md` with execution steps, maintenance guidelines, and troubleshooting tips.
+        - [ ] Provide onboarding material for other tracks to run tests locally.
+
+* **Internal Success Criteria:** Framework operational, priority tests implemented, data strategy in place, CI/CD integration completed.
+* **Internal Verification Method:** Review coverage metrics, ensure traceability to requirements, confirm documentation up to date.
+
+**5. Test Reporting Protocol (Internal)**
+Log build outcomes and coverage metrics in `docs/Test_Result_Analysis.md` tagged `TEST-PH2`.
+
+**6. Final Instruction for this Phase**
+Communicate test suite availability to other tracks and prepare for integration testing in Phase 3.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/testing/PHASE-3_INTEGRATION_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/testing/PHASE-3_INTEGRATION_v0.0.1.md
@@ -1,0 +1,47 @@
+**Subject: Phase 3: Testing Track — Cross-Track Integration Testing & Coordination for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Coordinate and execute integration and system-level testing across all tracks, ensuring quality gates are met. Testing team focuses on orchestration and execution of tests, not on fixing feature defects.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Follow integration dashboard schedule and testing strategy.
+* Apply standards `TEST-INTEG`, `TEST-SYS`, `TEST-UX`, `TEST-SEC`, and `DEFECT-MGMT`.
+* Maintain neutrality—log defects and assign to owning tracks.
+
+**3. Mandatory Quality & Finalization Rules**
+Store reports in `testing/outputs/phase-3/`, including integration execution logs, defect summaries, and quality metrics dashboards.
+
+**4. Directive Section: Testing Phase 3 Tasks**
+* **Input Context:**
+    * Component build artifacts, networking connectivity, security controls, UX requirements.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 3.1: Test Environment Confirmation** *(Setup)*
+        - [ ] Validate environment readiness (data, configurations, access) against Phase 1 plan.
+        - [ ] Document discrepancies and coordinate fixes.
+    - [ ] **Task 3.2: Integration Test Execution** *(Testing)*
+        - [ ] Run automated integration suites, capture results, and analyze failures.
+        - [ ] Conduct manual exploratory testing for end-to-end scenarios.
+    - [ ] **Task 3.3: Defect Management** *(Quality)*
+        - [ ] Log defects with reproduction steps, severity, and owning track.
+        - [ ] Facilitate triage meetings and track resolution status.
+    - [ ] **Task 3.4: Quality Metrics Reporting** *(Measurement)*
+        - [ ] Update dashboards with pass/fail rates, coverage, defect density, and readiness indicators.
+    - [ ] **Task 3.5: Communication & Alignment** *(Communication)*
+        - [ ] Publish `testing_integration_report.md` summarizing status, blockers, and go/no-go recommendations.
+        - [ ] Share results with architecture, frontend, backend, networking, security, and UX teams.
+
+* **Internal Success Criteria:** Integration suites executed, defects tracked, metrics updated, stakeholders informed.
+* **Internal Verification Method:** Review reports, ensure evidence stored, confirm neutrality (no feature changes).
+
+**5. Test Reporting Protocol (Internal)**
+Log integration outcomes in `docs/Test_Result_Analysis.md` tagged `TEST-PH3`.
+
+**6. Final Instruction for this Phase**
+Coordinate remediation retests and prepare for validation phase once critical defects resolved.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/testing/PHASE-4_VALIDATION_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/testing/PHASE-4_VALIDATION_v0.0.1.md
@@ -1,0 +1,47 @@
+**Subject: Phase 4: Testing Track — Validation Evidence & Release Gate Assessment for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Finalize validation activities across functional, non-functional, and compliance areas to certify release readiness. Testing team aggregates evidence and assesses go/no-go status.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Apply standards `TEST-VAL`, `PERF-TEST`, `SEC-TEST`, `UX-TEST`, and `DOC-VAL`.
+* Use release-candidate builds and final environments.
+* Ensure traceability to requirements and risk mitigations.
+
+**3. Mandatory Quality & Finalization Rules**
+Store outputs in `testing/outputs/phase-4/`, including validation summary, evidence index, and residual defect list with severities.
+
+**4. Directive Section: Testing Phase 4 Tasks**
+* **Input Context:**
+    * Integration reports, validation plans from other tracks, architecture certification checklist.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 4.1: Validation Scope Confirmation** *(Planning)*
+        - [ ] Ensure all planned test suites executed or explicitly waived.
+        - [ ] Update traceability matrix with final coverage status.
+    - [ ] **Task 4.2: Non-Functional Test Execution** *(Testing)*
+        - [ ] Run performance, resilience, accessibility, and security regression tests per plan.
+        - [ ] Capture metrics, compare to thresholds, and document deviations.
+    - [ ] **Task 4.3: Defect & Risk Assessment** *(Quality)*
+        - [ ] Consolidate remaining defects, categorize severity, and align on remediation/waiver decisions.
+        - [ ] Update risk register with validation outcomes.
+    - [ ] **Task 4.4: Evidence Compilation** *(Documentation)*
+        - [ ] Assemble `testing_validation_report.md` summarizing executed tests, results, and outstanding risks.
+        - [ ] Provide evidence index linking to logs, metrics, and supporting documents.
+    - [ ] **Task 4.5: Go/No-Go Recommendation** *(Governance)*
+        - [ ] Prepare recommendation for release readiness board with clear criteria and supporting data.
+
+* **Internal Success Criteria:** Validation plan completed, evidence compiled, recommendation prepared, stakeholders informed.
+* **Internal Verification Method:** Review traceability matrix, ensure all requirements have evidence or waivers; confirm documentation stored.
+
+**5. Test Reporting Protocol (Internal)**
+Log validation outcomes in `docs/Test_Result_Analysis.md` tagged `TEST-PH4`.
+
+**6. Final Instruction for this Phase**
+Present validation report to release governance body and support decision making.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*

--- a/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/testing/PHASE-5_RELEASE_v0.0.1.md
+++ b/STANDARDS_REPOSITORY/prompt-templates/Builder-Prompts/decomposed/testing/PHASE-5_RELEASE_v0.0.1.md
@@ -1,0 +1,48 @@
+**Subject: Phase 5: Testing Track — Release Support & Post-Launch Monitoring Setup for [Project Name]**
+
+**Date:** [Enter Current Date]
+**Time:** [Enter Current Time & UTC Offset]
+
+**1. Overall Purpose**
+Support production release by finalizing testing handoff materials, configuring post-launch monitoring, and defining regression plans. Testing team ensures ongoing quality oversight after go-live.
+
+**2. Core Execution Principles & Global Rules (MANDATORY)**
+* Follow `REL-TEST`, `OPS-TEST`, `DOC-HANDOFF`, and `POST-RELEASE` standards.
+* Use validation report, release plan, and governance playbook as guidance.
+* Provide clear instructions for operations and product teams on test execution during release.
+
+**3. Mandatory Quality & Finalization Rules**
+Store outputs in `testing/outputs/phase-5/`, including release test playbook, monitoring dashboards, regression schedule, and retrospective plan.
+
+**4. Directive Section: Testing Phase 5 Tasks**
+* **Input Context:**
+    * Testing validation report, release schedule, operations contact list.
+
+* **Execution Tasks (sequential):**
+    - [ ] **Task 5.1: Release Test Playbook** *(Enablement)*
+        - [ ] Document smoke tests, sanity checks, and rollback verification steps for release windows.
+        - [ ] Provide execution responsibilities and timing.
+    - [ ] **Task 5.2: Monitoring & Alert Configuration** *(Operations)*
+        - [ ] Set up dashboards tracking key quality metrics (errors, latency, UX signals).
+        - [ ] Configure alert thresholds and routing for test failures in production monitoring.
+    - [ ] **Task 5.3: Regression Planning** *(Planning)*
+        - [ ] Define post-release regression schedule and ownership.
+        - [ ] Identify areas requiring increased test automation post-launch.
+    - [ ] **Task 5.4: Knowledge Transfer** *(Communication)*
+        - [ ] Conduct handoff with operations/product teams, capturing questions and outstanding actions.
+        - [ ] Update `testing_runbook.md` with release support procedures.
+    - [ ] **Task 5.5: Retrospective Preparation** *(Improvement)*
+        - [ ] Schedule post-launch testing retrospective and outline metrics to review.
+        - [ ] Collect lessons learned to feed into future projects.
+
+* **Internal Success Criteria:** Release playbook published, monitoring configured, regression plan defined, handoff completed.
+* **Internal Verification Method:** Ensure deliverables stored, stakeholders acknowledge responsibilities, monitoring dashboards live.
+
+**5. Test Reporting Protocol (Internal)**
+Log release readiness confirmation in `docs/Test_Result_Analysis.md` tagged `TEST-PH5`.
+
+**6. Final Instruction for this Phase**
+Support go-live execution and monitor initial release window, ready to trigger regression or rollback procedures as needed.
+
+**7. Contextual Footer**
+*(Generated on: [Enter Current Date & Time]. Location: [Enter Locale].)*


### PR DESCRIPTION
## Summary
- rewrite the architecture track prompts to deliver the cross-track blueprint, guardrails, and sequencing packets other lanes consume
- tailor frontend, backend, networking, security, and testing prompts so each phase enforces its lane-specific scope, dependencies, and evidence
- update the UX/UI polish prompts to focus on experience assets, review feedback, and launch stewardship for the shared project

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db3305825c8326a976c38fc34921bd